### PR TITLE
[REF] Support of 'noupdate' in check 'duplicate-xml-record-id'

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -205,5 +205,10 @@ class WrapperModuleChecker(BaseChecker):
                 else [self.module, record.get('id')]
             if module and xml_module != module:
                 continue
-            xml_ids.append(xml_module + '.' + xml_id)
+            # Support case where use two xml_id:
+            #  1) With noupdate="1"
+            #  2) With noupdate="0"
+            noupdate = "noupdate=" + record.getparent().get('noupdate', '0')
+            xml_ids.append(
+                xml_module + '.' + xml_id + '.' + noupdate)
         return xml_ids

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -205,7 +205,7 @@ class WrapperModuleChecker(BaseChecker):
                 else [self.module, record.get('id')]
             if module and xml_module != module:
                 continue
-            # Support case where use two xml_id:
+            # Support case where using two xml_id:
             #  1) With noupdate="1"
             #  2) With noupdate="0"
             noupdate = "noupdate=" + record.getparent().get('noupdate', '0')

--- a/pylint_odoo/test_repo/test_module/res_users.xml
+++ b/pylint_odoo/test_repo/test_module/res_users.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="group_users" model="res.users">
+      <field name="name">Moy6</field>
+      <field name="login">moylop260</field>
+    </record>
+
+  </data>
+
+  <data noupdate="1">
+    <record id="group_users" model="res.users">
+      <field name="password">change_password</field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
Many times we need duplicate a xml_id one with noupdate="1" and another one
with noupdate="0"
Fix OCA/maintainer-quality-tools#276