### PR TITLE
[IMP] Add check 'create-user-without-reset-password'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,5 @@ exclude_lines =
     if __name__ == '__main__':
     # Don't complain about uninstalled packages
     except OSError as oserr:
+    except NameError:
+    except SyntaxError:

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -205,5 +205,10 @@ class WrapperModuleChecker(BaseChecker):
                 else [self.module, record.get('id')]
             if module and xml_module != module:
                 continue
-            xml_ids.append(xml_module + '.' + xml_id)
+            # Support case where use two xml_id:
+            #  1) With noupdate="1"
+            #  2) With noupdate="0"
+            noupdate = "noupdate=" + record.getparent().get('noupdate', '0')
+            xml_ids.append(
+                xml_module + '.' + xml_id + '.' + noupdate)
         return xml_ids

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -8,7 +8,7 @@ from pylint.lint import Run
 from pylint_odoo import misc
 
 
-EXPECTED_ERRORS = 46
+EXPECTED_ERRORS = 47
 
 
 class MainTest(unittest.TestCase):

--- a/pylint_odoo/test_repo/test_module/res_users.xml
+++ b/pylint_odoo/test_repo/test_module/res_users.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="group_users" model="res.users">
+      <field name="name">Moy6</field>
+      <field name="login">moylop260</field>
+    </record>
+
+  </data>
+
+  <data noupdate="1">
+    <record id="group_users" model="res.users">
+      <field name="password">change_password</field>
+    </record>
+
+  </data>
+</openerp>

--- a/pylint_odoo/test_repo/test_module/res_users.xml
+++ b/pylint_odoo/test_repo/test_module/res_users.xml
@@ -2,9 +2,14 @@
 <openerp>
   <data>
 
-    <record id="group_users" model="res.users">
+    <record id="group_users" model="res.users" context="{'no_reset_password': True}">
       <field name="name">Moy6</field>
       <field name="login">moylop260</field>
+    </record>
+
+    <record id="group_users2" model="res.users">
+      <field name="name">Admin 2</field>
+      <field name="login">admin_2</field>
     </record>
 
   </data>


### PR DESCRIPTION
Many times we have next traceback in our customer builds projects:
```bash
2015-10-08 20:32:43,139 232 ERROR openerp_test openerp.addons.base.ir.ir_mail_server: Mail delivery failed via SMTP server 'localhost'.
error: 111
Connection refused
2015-10-08 20:32:43,139 232 ERROR openerp_test openerp.addons.mail.mail_mail: failed sending mail.mail 21
Traceback (most recent call last):
File "addons/mail/mail_mail.py", line 304, in send
context=context)
File "openerp/api.py", line 241, in wrapper
return old_api(self, *args, **kwargs)
File "openerp/addons/base/ir/ir_mail_server.py", line 503, in send_email
raise MailDeliveryException(_("Mail Delivery Failed"), msg)
MailDeliveryException: ('Mail Delivery Failed', u"Mail delivery failed via SMTP server 'localhost'.\nerror: 111\nConnection refused")
```

The module [auth_signup](https://github.com/odoo/odoo/blob/c4844675b83e299b5d9f81418142c61688f4546a/addons/auth_signup/res_users.py#L303-L306) avoid this traceback with a context when you create users.

```xml
...
 <record model="res.users" id="external_id" context="{'no_reset_password': True}">
    <field name="name">Test user 1</field>
    <field name="login">test_user1</field>
    ...
...
```

IMHO If we create a user should avoid future traceback with other projects that use `auth_signup` module.