### PR TITLE
[ADD] translation-required: Add check to required even a translation

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -371,6 +371,14 @@ class NoModuleChecker(BaseChecker):
 
     @utils.check_messages('translation-required')
     def visit_raise(self, node):
+        """Visit raise and search methods with a string parameter
+        without a method.
+        Example wrong: raise UserError('My String')
+        Example done: raise UserError(_('My String'))
+        TODO: Consider the case where is used a variable with string value
+              my_string = 'My String'  # wrong
+              raise UserError(my_string)  # Detect variable string here
+        """
         args = misc.join_node_args_kwargs(node.last_child())
         for argument in args:
             if isinstance(argument, astroid.Const) and \

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -36,6 +36,15 @@ def get_sum_fails(pylint_stats):
         for msg in pylint_stats['by_msg']])
 
 
+def join_node_args_kwargs(node):
+    """Method to join args and keywords
+    :param node: node to get args and keywords
+    :return: List of args
+    """
+    args = node.args + getattr(node, 'keywords', [])
+    return args
+
+
 # TODO: Change all methods here
 
 class WrapperModuleChecker(BaseChecker):

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -35,6 +35,7 @@ EXPECTED_ERRORS = {
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,
     'translation-field': 2,
+    'translation-required': 2,
     'use-vim-comment': 1,
     'xml-syntax-error': 2,
 }

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from openerp import fields, models, _
+from openerp.exceptions import Warning as UserError
 
 
 def function_no_method():
@@ -35,3 +36,27 @@ class TestModel(models.Model):
 
     def my_method2(self, variable2):
         return variable2
+
+    def my_method6(self):
+        user_id = 1
+        if user_id != 99:
+            # Method without translation
+            raise UserError('String without translation')
+
+    def my_method7(self):
+        user_id = 1
+        if user_id != 99:
+            # Method with translation
+            raise UserError(_('String with translation'))
+
+    def my_method8(self):
+        user_id = 1
+        if user_id != 99:
+            str_error = 'String with translation 2'  # Don't check
+            raise UserError(str_error)
+
+    def my_method9(self):
+        user_id = 1
+        if user_id != 99:
+            # Method without translation
+            raise UserError("String without translation 2")


### PR DESCRIPTION
This check is part of the <a href='https://github.com/OCA/pylint-odoo/issues/14'>roadmap</a> Methods that required even a translation (warning, errors...)
Many times we have warning or error exceptions and we forget to add the method translate _('mystring') in our string.
This check review all methods where a translation is required and just have a string directly by param.
