### PR TITLE
[FIX] join_node_args_kwargs: AttributeError

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -41,7 +41,8 @@ def join_node_args_kwargs(node):
     :param node: node to get args and keywords
     :return: List of args
     """
-    args = node.args + getattr(node, 'keywords', [])
+    args = (getattr(node, 'args', None) or []) + \
+        (getattr(node, 'keywords', None) or [])
     return args
 
 

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -60,3 +60,7 @@ class TestModel(models.Model):
         if user_id != 99:
             # Method without translation
             raise UserError("String without translation 2")
+
+    def my_method10(self):
+        # A example of built-in raise without parameters
+        raise ZeroDivisionError


### PR DESCRIPTION
I tested the new pylint-odoo-2.0.0 of MQT here:
https://github.com/OCA/account-financial-reporting/pull/189#issuecomment-219645638

And I saw the following error:
```bash
  File "pylint_odoo/misc.py", line 44, in join_node_args_kwargs
    args = node.args + getattr(node, 'keywords', [])
AttributeError: 'Name' object has no attribute 'args'
```
