### PR TITLE
[IMP] pylint_odoo: Enable cProfile print stats and improve performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 
 script:
     - flake8 --exclude=__init__.py .
-    - tox -e $TOXENV
+    - tox -e $TOXENV,profile-stats
 
 after_success:
     - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-pylint{14,20}
+envlist = clean,py27-pylint{14,20},profile-stats
 skip_missing_interpreters = true
 
 [base]
@@ -18,7 +18,24 @@ deps =
     py27-pylint20: git+https://github.com/PyCQA/astroid@master
     py27-pylint20: git+https://github.com/PyCQA/pylint@master
    {[base]deps}
+setenv =
+    PYLINT_ODOO_STATS = {toxinidir}/.cprofile_{envname}
 
 commands =
     coverage run setup.py test
     coverage report -m
+
+[testenv:profile-stats]
+deps =
+    pstats_print2list
+skip_install = true
+commands =
+    python -c "from glob import glob;from pstats_print2list import get_pstats_print2list,print_pstats_list;fnames=glob('{toxinidir}/.cprofile_*.stats');print_pstats_list(get_pstats_print2list(fnames, sort='cumulative', filter_fnames=['pylint_odoo'], limit=15));print_pstats_list(get_pstats_print2list(fnames, sort='calls', filter_fnames=['pylint_odoo'], limit=15))"
+
+[testenv:clean]
+deps =
+    coverage
+skip_install = true
+commands =
+    coverage erase
+    python -c "import os;from glob import glob;map(os.remove, glob('{toxinidir}/.cprofile_*.stats'))"


### PR DESCRIPTION
- Add a profiling report of top five `pytlint_odoo` methods more time consuming or more times executed.

e.g.
<img width="936" alt="screen shot 2016-05-21 at 2 26 45 pm" src="https://cloud.githubusercontent.com/assets/6644187/15450399/1617fc82-1f60-11e6-945a-b8a612088d86.png">

 - This report is useful for developers to improve performance.

 - Improve performance, now show minor cProfile values:
<img width="1279" alt="screen shot 2016-05-21 at 4 50 56 pm" src="https://cloud.githubusercontent.com/assets/6644187/15450995/38f81afc-1f74-11e6-908e-3ce55655f379.png">
