### PR TITLE
[FIX] duplicate-xml-fields: Support security xml style

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -253,7 +253,9 @@ class WrapperModuleChecker(BaseChecker):
                 else [self.module, record.get('id')]
             list_fields = record.xpath('field')
             for field in list_fields:
-                field_xml = field.values()[0]
+                field_xml = field.attrib.get('name')
+                if not field_xml:
+                    continue
                 xml_fields.append('.'.join(
                     [xml_module, xml_id, field_xml]))
                 list_xpaths = ['*/field', '*/field/*/field']

--- a/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
@@ -41,7 +41,17 @@
                 </xpath>
             </field>
         </record>
-
+        <!-- Records with first item different to 'name'-->
+        <record model="ir.rule" id="access_rule">
+            <field name="name">Access rule</field>
+            <field name="model_id" ref="model_test_model"/>
+            <field eval="1" name="perm_read"/>
+            <field eval="0" name="perm_create"/>
+            <field eval="0" name="perm_write"/>
+            <field eval="0" name="perm_unlink"/>
+            <field name="domain_force">[('user_ids','in',user.id)]</field>
+            <field domain="[('user', '=', user)]"/> <!--field without name-->
+        </record>
         <!-- duplicate record field "arch" -->
         <record id="view_model_form3" model="ir.ui.view">
             <field name="arch">test.model5</field>


### PR DESCRIPTION
The old sentence `field.values()[0]` returns the first item from `field xml` sentence in most cases it works well.

But if we have a style different like as `<field eval="1" name="perm_read"/>` we should process the second one.

Then I change to `field.attrib.get('name')` sentence to avoid future problem with styles.

Detected from: https://travis-ci.org/OCA/server-tools/jobs/132336867#L423