### PR TITLE
[IMP] javascript-lint: Enable jshint configuration file

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -83,6 +83,10 @@ ODOO_MSGS = {
 DFTL_README_TMPL_URL = 'https://github.com/OCA/maintainer-tools' + \
     '/blob/master/template/module/README.rst'
 DFTL_EXTFILES_TO_LINT = ['xml', 'csv', 'po', 'js', 'mako']
+DFTL_JSHINTRC = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'examples', '.jshintrc'
+)
 
 
 class ModuleChecker(misc.WrapperModuleChecker):
@@ -100,6 +104,14 @@ class ModuleChecker(misc.WrapperModuleChecker):
             'metavar': '<comma separated values>',
             'default': DFTL_EXTFILES_TO_LINT,
             'help': 'List of extension files to check separated by a comma.'
+        }),
+        ('jshintrc', {
+            'type': 'string',
+            'metavar': '<path to file>',
+            'default': DFTL_JSHINTRC,
+            'help': ('A path to a file that contains a configuration file of '
+                     'jshint. Default file based on https://github.com/'
+                     'jshint/jshint/blob/master/examples/.jshintrc')
         }),
     )
 
@@ -265,7 +277,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
             if 'lib' in os.path.dirname(js_file_rel).split(os.sep):
                 continue
             js_file = os.path.join(self.module_path, js_file_rel)
-            errors = self.check_js_lint(js_file)
+            errors = self.check_js_lint(js_file, self.config.jshintrc)
             for error in errors:
                 self.msg_args.append((js_file_rel + error,))
         if self.msg_args:

--- a/pylint_odoo/examples/.jshintrc
+++ b/pylint_odoo/examples/.jshintrc
@@ -1,0 +1,91 @@
+{
+    // JSHint Default Configuration File (as on JSHint website)
+    // See http://jshint.com/docs/ for more details
+
+    "maxerr"        : 50,       // {int} Maximum error before stopping
+
+    // Enforcing
+    "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
+    "camelcase"     : false,    // true: Identifiers must be in camelCase
+    "curly"         : true,     // true: Require {} for every new block or scope
+    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
+    "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
+    "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "latedef"       : false,    // true: Require variables/functions to be defined before being used
+    "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
+    "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
+    "plusplus"      : false,    // true: Prohibit use of `++` and `--`
+    "quotmark"      : false,    // Quotation mark consistency:
+                                //   false    : do nothing (default)
+                                //   true     : ensure whatever is used is consistent
+                                //   "single" : require single quotes
+                                //   "double" : require double quotes
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "unused"        : true,     // Unused variables:
+                                //   true     : all variables, last function parameter
+                                //   "vars"   : all variables only
+                                //   "strict" : all variables, all function parameters
+    "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+    "maxparams"     : false,    // {int} Max number of formal params allowed per function
+    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
+    "maxstatements" : false,    // {int} Max number statements per function
+    "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
+    "maxlen"        : false,    // {int} Max number of characters per line
+    "varstmt"       : false,    // true: Disallow any var statements. Only `let` and `const` are allowed.
+
+    // Relaxing
+    "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+    "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+    "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+    "eqnull"        : false,     // true: Tolerate use of `== null`
+    "esversion"     : 5,         // {int} Specify the ECMAScript version to which the code must adhere.
+    "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
+                                 // (ex: `for each`, multiple try/catch, function expression…)
+    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
+    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : false,     // true: Tolerate defining variables inside control statements
+    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+    "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+    "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxcomma"      : false,     // true: Tolerate comma-first style coding
+    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+    "multistr"      : false,     // true: Tolerate multi-line strings
+    "noyield"       : false,     // true: Tolerate generator functions with no yield statement in them.
+    "notypeof"      : false,     // true: Tolerate invalid typeof operator values
+    "proto"         : false,     // true: Tolerate using the `__proto__` property
+    "scripturl"     : false,     // true: Tolerate script-targeted URLs
+    "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+    "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+    "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+    "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+
+    // Environments
+    "browser"       : true,     // Web Browser (window, document, etc)
+    "browserify"    : false,    // Browserify (node.js code in the browser)
+    "couch"         : false,    // CouchDB
+    "devel"         : true,     // Development/debugging (alert, confirm, etc)
+    "dojo"          : false,    // Dojo Toolkit
+    "jasmine"       : false,    // Jasmine
+    "jquery"        : false,    // jQuery
+    "mocha"         : true,     // Mocha
+    "mootools"      : false,    // MooTools
+    "node"          : false,    // Node.js
+    "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
+    "phantom"       : false,    // PhantomJS
+    "prototypejs"   : false,    // Prototype and Scriptaculous
+    "qunit"         : false,    // QUnit
+    "rhino"         : false,    // Rhino
+    "shelljs"       : false,    // ShellJS
+    "typed"         : false,    // Globals for typed array constructions
+    "worker"        : false,    // Web Workers
+    "wsh"           : false,    // Windows Scripting Host
+    "yui"           : false,    // Yahoo User Interface
+
+    // Custom Globals
+    "globals"       : {}        // additional predefined global variables
+}

--- a/pylint_odoo/examples/.jshintrc
+++ b/pylint_odoo/examples/.jshintrc
@@ -125,6 +125,8 @@
         "callback": false,
         "framework": false,
         "input_value": false,
-        "fuzzy": false
+        "fuzzy": false,
+        "CuteEdge": false,
+        "ace": false
     }
 }

--- a/pylint_odoo/examples/.jshintrc
+++ b/pylint_odoo/examples/.jshintrc
@@ -88,5 +88,10 @@
 
     // "unused": false,  // More options http://jshint.com/docs/options/
     // Custom Globals
-    "globals"       : {}        // additional predefined global variables
+    "globals"       : {
+        // additional predefined global variables
+        "openerp": false,  // odoo variable
+        "odoo": false,  // support possible future odoo variable
+        "_": false  // Translation method of odoo
+    }
 }

--- a/pylint_odoo/examples/.jshintrc
+++ b/pylint_odoo/examples/.jshintrc
@@ -8,7 +8,7 @@
     "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
     "camelcase"     : false,    // true: Identifiers must be in camelCase
     "curly"         : true,     // true: Require {} for every new block or scope
-    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "eqeqeq"        : false,     // true: Require triple equals (===) for comparison
     "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
     "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
     "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
@@ -18,7 +18,7 @@
     "noempty"       : true,     // true: Prohibit use of empty blocks
     "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
     "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
-    "plusplus"      : true,     // true: Prohibit use of `++` and `--` Changed to true
+    "plusplus"      : false,     // true: Prohibit use of `++` and `--`
     "quotmark"      : false,    // Quotation mark consistency:
                                 //   false    : do nothing (default)
                                 //   true     : ensure whatever is used is consistent
@@ -34,7 +34,7 @@
     "maxdepth"      : 5,        // {int} Max depth of nested blocks (within functions)
     "maxstatements" : 50,    // {int} Max number statements per function
     "maxcomplexity" : 15,    // {int} Max cyclomatic complexity per function
-    "maxlen"        : 120,    // {int} Max number of characters per line
+    "maxlen"        : 0,    // {int} Max number of characters per line
     "varstmt"       : false,    // true: Disallow any var statements. Only `let` and `const` are allowed.
 
     // Relaxing

--- a/pylint_odoo/examples/.jshintrc
+++ b/pylint_odoo/examples/.jshintrc
@@ -78,7 +78,7 @@
     "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
     "phantom"       : false,    // PhantomJS
     "prototypejs"   : false,    // Prototype and Scriptaculous
-    "qunit"         : false,    // QUnit
+    "qunit"         : true,    // QUnit
     "rhino"         : false,    // Rhino
     "shelljs"       : false,    // ShellJS
     "typed"         : false,    // Globals for typed array constructions
@@ -90,8 +90,41 @@
     // Custom Globals
     "globals"       : {
         // additional predefined global variables
-        "openerp": false,  // odoo variable
-        "odoo": false,  // support possible future odoo variable
-        "_": false  // Translation method of odoo
+        // alert, console, confirm, Debug, propmt, opera are developer variables
+        // escape, unescape are that are not part of ECMAScript standard
+        "openerp": false,   // odoo variable
+        "odoo": false,      // support possible future odoo variable
+        "_": false,         // Translation method of odoo
+        "self": false,      // python fashion
+        // variables extracted from odoo addons js files
+        "nv": false,
+        "google": false,
+        "d3": false,
+        "confirm": false,
+        "moment": false,
+        "website_ga": false,
+        "ZeroClipboard": false,
+        "MarkerClusterer": false,
+        "odoo_partner_data": false,
+        "init_kanban": false,
+        "gapi": false,
+        "ActiveXObject": false,
+        "vkbeautify": false,
+        "snippets_url": false,
+        "Vec2": false,
+        "CuteGraph": false,
+        "StripeCheckout": false,
+        "FastClick": false,
+        "py": false,
+        "xyz": false,
+        "QWeb2": false,
+        "e": false,
+        "Raphael": false,
+        "CuteNode": false,
+        "css": false,
+        "callback": false,
+        "framework": false,
+        "input_value": false,
+        "fuzzy": false
     }
 }

--- a/pylint_odoo/examples/.jshintrc
+++ b/pylint_odoo/examples/.jshintrc
@@ -65,7 +65,7 @@
     "validthis"     : false,     // true: Tolerate using this in a non-constructor function
 
     // Environments
-    "browser"       : false,     // Web Browser (window, document, etc)
+    "browser"       : true,     // Web Browser (window, document, etc)
     "browserify"    : true,    // Browserify (node.js code in the browser)
     "couch"         : false,    // CouchDB
     "devel"         : false,     // Development/debugging (alert, confirm, etc)

--- a/pylint_odoo/examples/.jshintrc
+++ b/pylint_odoo/examples/.jshintrc
@@ -1,8 +1,8 @@
 {
-    // JSHint Default Configuration File (as on JSHint website)
+    // JSHint Default Configuration File (as on JSHint website plus custom changes)
     // See http://jshint.com/docs/ for more details
 
-    "maxerr"        : 50,       // {int} Maximum error before stopping
+    "maxerr"        : 15,       // {int} Maximum error before stopping
 
     // Enforcing
     "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
@@ -18,7 +18,7 @@
     "noempty"       : true,     // true: Prohibit use of empty blocks
     "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
     "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
-    "plusplus"      : false,    // true: Prohibit use of `++` and `--`
+    "plusplus"      : true,     // true: Prohibit use of `++` and `--` Changed to true
     "quotmark"      : false,    // Quotation mark consistency:
                                 //   false    : do nothing (default)
                                 //   true     : ensure whatever is used is consistent
@@ -29,12 +29,12 @@
                                 //   true     : all variables, last function parameter
                                 //   "vars"   : all variables only
                                 //   "strict" : all variables, all function parameters
-    "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+    "strict"        : false,     // true: Requires all functions run in ES5 Strict Mode
     "maxparams"     : false,    // {int} Max number of formal params allowed per function
-    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
-    "maxstatements" : false,    // {int} Max number statements per function
-    "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
-    "maxlen"        : false,    // {int} Max number of characters per line
+    "maxdepth"      : 5,        // {int} Max depth of nested blocks (within functions)
+    "maxstatements" : 50,    // {int} Max number statements per function
+    "maxcomplexity" : 15,    // {int} Max cyclomatic complexity per function
+    "maxlen"        : 120,    // {int} Max number of characters per line
     "varstmt"       : false,    // true: Disallow any var statements. Only `let` and `const` are allowed.
 
     // Relaxing
@@ -48,7 +48,7 @@
     "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
     "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
     "funcscope"     : false,     // true: Tolerate defining variables inside control statements
-    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+    "globalstrict"  : true,     // true: Allow global "use strict" (also enables 'strict')
     "iterator"      : false,     // true: Tolerate using the `__iterator__` property
     "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
     "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
@@ -65,16 +65,16 @@
     "validthis"     : false,     // true: Tolerate using this in a non-constructor function
 
     // Environments
-    "browser"       : true,     // Web Browser (window, document, etc)
-    "browserify"    : false,    // Browserify (node.js code in the browser)
+    "browser"       : false,     // Web Browser (window, document, etc)
+    "browserify"    : true,    // Browserify (node.js code in the browser)
     "couch"         : false,    // CouchDB
-    "devel"         : true,     // Development/debugging (alert, confirm, etc)
+    "devel"         : false,     // Development/debugging (alert, confirm, etc)
     "dojo"          : false,    // Dojo Toolkit
     "jasmine"       : false,    // Jasmine
-    "jquery"        : false,    // jQuery
-    "mocha"         : true,     // Mocha
+    "jquery"        : true,    // jQuery
+    "mocha"         : false,     // Mocha
     "mootools"      : false,    // MooTools
-    "node"          : false,    // Node.js
+    "node"          : false,     // Node.js
     "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
     "phantom"       : false,    // PhantomJS
     "prototypejs"   : false,    // Prototype and Scriptaculous
@@ -86,6 +86,7 @@
     "wsh"           : false,    // Windows Scripting Host
     "yui"           : false,    // Yahoo User Interface
 
+    // "unused": false,  // More options http://jshint.com/docs/options/
     // Custom Globals
     "globals"       : {}        // additional predefined global variables
 }

--- a/pylint_odoo/examples/.jshintrc
+++ b/pylint_odoo/examples/.jshintrc
@@ -24,7 +24,7 @@
                                 //   true     : ensure whatever is used is consistent
                                 //   "single" : require single quotes
                                 //   "double" : require double quotes
-    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "undef"         : false,     // true: Require all non-global variables to be declared (prevents global leaks)
     "unused"        : true,     // Unused variables:
                                 //   true     : all variables, last function parameter
                                 //   "vars"   : all variables only
@@ -90,43 +90,5 @@
     // Custom Globals
     "globals"       : {
         // additional predefined global variables
-        // alert, console, confirm, Debug, propmt, opera are developer variables
-        // escape, unescape are that are not part of ECMAScript standard
-        "openerp": false,   // odoo variable
-        "odoo": false,      // support possible future odoo variable
-        "_": false,         // Translation method of odoo
-        "self": false,      // python fashion
-        // variables extracted from odoo addons js files
-        "nv": false,
-        "google": false,
-        "d3": false,
-        "confirm": false,
-        "moment": false,
-        "website_ga": false,
-        "ZeroClipboard": false,
-        "MarkerClusterer": false,
-        "odoo_partner_data": false,
-        "init_kanban": false,
-        "gapi": false,
-        "ActiveXObject": false,
-        "vkbeautify": false,
-        "snippets_url": false,
-        "Vec2": false,
-        "CuteGraph": false,
-        "StripeCheckout": false,
-        "FastClick": false,
-        "py": false,
-        "xyz": false,
-        "QWeb2": false,
-        "e": false,
-        "Raphael": false,
-        "CuteNode": false,
-        "css": false,
-        "callback": false,
-        "framework": false,
-        "input_value": false,
-        "fuzzy": false,
-        "CuteEdge": false,
-        "ace": false
     }
 }

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -138,12 +138,15 @@ class WrapperModuleChecker(BaseChecker):
         """
         return rst_lint(fname)
 
-    def check_js_lint(self, fname):
+    def check_js_lint(self, fname, frc=None):
         """Check javascript lint in fname.
         :param fname: String with full path of file to check
+        :param frc: String with full path of configuration file of jshint
         :return: Return list of errors.
         """
         cmd = ['jshint', '--reporter=unix', fname]
+        if frc:
+            cmd.append('--config=' + frc)
         try:
             output = subprocess.Popen(
                 cmd, stderr=subprocess.STDOUT,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -22,7 +22,7 @@ EXPECTED_ERRORS = {
     'duplicate-xml-record-id': 2,
     'incoherent-interpreter-exec-perm': 3,
     'invalid-commit': 4,
-    'javascript-lint': 2,
+    'javascript-lint': 5,
     'license-allowed': 1,
     'manifest-author-string': 1,
     'manifest-deprecated-key': 1,

--- a/pylint_odoo/test_repo/broken_module/broken_example.js
+++ b/pylint_odoo/test_repo/broken_module/broken_example.js
@@ -2,4 +2,5 @@ $(document).ready(function () {
     $('.example').each(function () {
         var oe_website_sale = this;
     }) /*missing semicolon*/
+    console.log("This is similar to a print");
 }) /*missing semicolon*/


### PR DESCRIPTION
- [x] Enable configuration file for jshint to enable or disable checks and other custom configurations.
- [x] <s>Enable `console*` check</s> To detect a `console.log` we need all globals variables to use https://github.com/jshint/jshint/issues/2979#issuecomment-232212913 ... to add all variables we need all source js files... then this is not static check... search other way
- [x] Disable https://jslinterrors.com/expected-an-assignment-or-function-call
