### PR TITLE
[ADD] old-api7-method-defined: Emit message if the method defined have (self, cr, uid)

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -175,6 +175,11 @@ ODOO_MSGS = {
         'method-inverse',
         settings.DESC_DFLT
     ),
+    'R%d10' % settings.BASE_NOMODULE_ID: (
+        'Method defined with old api version 7',
+        'old-api7-method-defined',
+        settings.DESC_DFLT
+    ),
 }
 
 DFTL_MANIFEST_REQUIRED_KEYS = ['license']
@@ -370,7 +375,8 @@ class NoModuleChecker(BaseChecker):
 
     @utils.check_messages('api-one-multi-together',
                           'copy-wo-api-one', 'api-one-deprecated',
-                          'method-required-super')
+                          'method-required-super', 'old-api7-method-defined',
+                          )
     def visit_functiondef(self, node):
         """Check that `api.one` and `api.multi` decorators not exists together
         Check that method `copy` exists `api.one` decorator
@@ -407,6 +413,11 @@ class NoModuleChecker(BaseChecker):
             if 'super' not in calls:
                 self.add_message('method-required-super',
                                  node=node, args=(node.name))
+
+        if self.linter.is_message_enabled('old-api7-method-defined'):
+            first_args = [arg.name for arg in node.args.args][:3]
+            if first_args == ['self', 'cr', 'uid']:
+                self.add_message('old-api7-method-defined', node=node)
 
     visit_function = visit_functiondef
 

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -416,7 +416,9 @@ class NoModuleChecker(BaseChecker):
 
         if self.linter.is_message_enabled('old-api7-method-defined'):
             first_args = [arg.name for arg in node.args.args][:3]
-            if first_args == ['self', 'cr', 'uid']:
+            if len(first_args) == 3 and first_args[0] == 'self' and \
+               first_args[1] in ['cr', 'cursor'] and \
+               first_args[2] in ['uid', 'user', 'user_id']:
                 self.add_message('old-api7-method-defined', node=node)
 
     visit_function = visit_functiondef

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -39,7 +39,7 @@ EXPECTED_ERRORS = {
     'missing-readme': 1,
     'no-utf8-coding-comment': 3,
     'odoo-addons-relative-import': 4,
-    'old-api7-method-defined': 1,
+    'old-api7-method-defined': 2,
     'openerp-exception-warning': 3,
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -39,6 +39,7 @@ EXPECTED_ERRORS = {
     'missing-readme': 1,
     'no-utf8-coding-comment': 3,
     'odoo-addons-relative-import': 4,
+    'old-api7-method-defined': 1,
     'openerp-exception-warning': 3,
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -133,7 +133,7 @@ class TestModel(models.Model):
         self.cr.execute(
             'SELECT name FROM account WHERE id IN %s', (tuple(ids),))
 
-    def sql_injection_method(self, cr, ids):
+    def sql_injection_method(self, cr, uid, ids, context=None):  # old api
         # SQL injection, bad way
         self._cr.execute(
             'SELECT name FROM account WHERE id IN %s' % (tuple(ids),))

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -133,6 +133,9 @@ class TestModel(models.Model):
         self.cr.execute(
             'SELECT name FROM account WHERE id IN %s', (tuple(ids),))
 
+    def old_api_method_alias(self, cursor, user, ids, context=None):  # old api
+        pass
+
     def sql_injection_method(self, cr, uid, ids, context=None):  # old api
         # SQL injection, bad way
         self._cr.execute(


### PR DESCRIPTION
```python
def my_method(self, cr, uid, ids, context=None):  # method old api v7
    pass
```

Idea for v9 projects to easiest migration to v10 where the old api should be deprecated.
NOTE: This PR don't enable the check in MQT, but is required for our local process, we can discuss the enabling in MQT project.