### PR TITLE
[REF] import-error: Skip openerp or odoo import because is a runtime import

### DIFF
--- a/pylint_odoo/augmentations/main.py
+++ b/pylint_odoo/augmentations/main.py
@@ -31,6 +31,18 @@ def is_valid_openerp_osv_deprecated(node):
     return False
 
 
+def is_openerp_import(node):
+    """Verify if the node is a import openerp
+    :returns: True if is a openerp import
+    :rtype: boolean
+    """
+    modules = [submodule[0].split('.')[0] for submodule in node.names]
+    modules.append(getattr(node, 'modname', '').split('.')[0])
+    if 'odoo' in modules or 'openerp' in modules:
+        return True
+    return False
+
+
 def apply_augmentations(linter):
     """Apply suppression rules."""
 
@@ -46,3 +58,12 @@ def apply_augmentations(linter):
     discard = hasattr(ImportsChecker, 'visit_from') and \
         ImportsChecker.visit_from or ImportsChecker.visit_importfrom
     suppress_message(linter, discard, 'W0402', is_valid_openerp_osv_deprecated)
+
+    # E0401 - import-error
+    # if the package is openerp then should be ignored because
+    # is a runtime valid import
+    discard = ImportsChecker.visit_import
+    suppress_message(linter, discard, 'E0401', is_openerp_import)
+    discard = hasattr(ImportsChecker, 'visit_from') and \
+        ImportsChecker.visit_from or ImportsChecker.visit_importfrom
+    suppress_message(linter, discard, 'E0401', is_openerp_import)

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -21,6 +21,7 @@ EXPECTED_ERRORS = {
     'duplicate-id-csv': 2,
     'duplicate-xml-fields': 6,
     'duplicate-xml-record-id': 2,
+    'import-error': 4,
     'incoherent-interpreter-exec-perm': 3,
     'invalid-commit': 4,
     'javascript-lint': 2,
@@ -72,7 +73,8 @@ class MainTest(unittest.TestCase):
             self.paths_modules.append(os.path.join(root, path))
         self.default_extra_params = [
             '--disable=all',
-            '--enable=odoolint,pointless-statement,trailing-newlines',
+            '--enable=odoolint,pointless-statement,trailing-newlines,'
+            'import-error',
         ]
         self.profile = Profile()
         self.sys_path_origin = list(sys.path)

--- a/pylint_odoo/test_repo/broken_module/models/model_inhe1.py
+++ b/pylint_odoo/test_repo/broken_module/models/model_inhe1.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+
+from openerp import models
+
+# to tests a suppression of a import-error
+from odoo import tools
+import odoo
+import odoo.addons as addons
+from odoo.addons.module.models import partner
+
+import no_exists
+from no_exists import package
+
+
+class TestModel(models.Model):
+    _inherit = 'res.company'
+
+    def method(self):
+        return tools, odoo, addons, partner, no_exists, package
+
+
+class TestModel2(models.Model):
+    _inherit = 'model.no.duplicated'


### PR DESCRIPTION
If you use a IDEs with `pylint` checkers supports then this change is for you.
Suppress the error `import-error` for `import openerp.addons.mymodule` cases because is a runtime `import`
Same case for `import openerp` isn't a runtime import but many times we don't wish added it to our `PYTHONPATH` or install it.

If you use `PYTHONPATH` then the import-error isn't emitted and this change won't affect you
