### PR TITLE
[REF] tox: Freeze stable sha pylint20

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ deps =
 deps =
     py27-pylint14: astroid==1.4.6
     py27-pylint14: pylint==1.5.6
-    py27-pylint20: git+https://github.com/PyCQA/astroid@master
-    py27-pylint20: git+https://github.com/PyCQA/pylint@master
+    py27-pylint20: git+https://github.com/PyCQA/astroid@461e016
+    py27-pylint20: git+https://github.com/PyCQA/pylint@0495355
    {[base]deps}
 setenv =
     PYLINT_ODOO_STATS = {toxinidir}/.cprofile_{envname}


### PR DESCRIPTION
We are using pylint==1.4 from requirements.txt
But we are using a unreleased pylint==2.0 (master branch) from tox in order to verify future compatibility with our checks.
Just now there is a error to install master package, then we need freeze a stable sha in order to avoid flaky errors in the future.
