### PR TITLE
[REF] Add bumpversion utility support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,13 @@
+# To auto increase the version {major.minor.patch} use the commands:
+#   bumpversion (major|minor|patch)
+# To sign commit for travis auto-deploy:
+#   git commit --amend -s
+#   git push origin master --tags
+
+[bumpversion]
+current_version = 1.3.2
+commit = True
+tag = True
+
+[bumpversion:file:pylint_odoo/__init__.py]
+

--- a/pylint_odoo/__init__.py
+++ b/pylint_odoo/__init__.py
@@ -1,4 +1,7 @@
 
+__version__ = "1.3.2"
+
+
 from . import checkers
 from . augmentations.main import apply_augmentations
 


### PR DESCRIPTION
Integrate [bumpversion](https://pypi.python.org/pypi/bumpversion) utility to auto increase the version `{major.minor.patch}` using the following commands:
  - For increase .patch
     -  `bumpversion patch --tag`
  - For increase .minor
     -  `bumpversion minor --tag`
  - For increase .major
     - `bumpversion major --tag`

To sign the commit for auto-deploy for travis
  - `git commit --amend -s`
  - `git push origin master --tags`


Allow get the version installed with:
`python -c "import pylint_odoo; print pylint_odoo.__version__"`