### PR TITLE
[ADD] prefer-other-formatting: Avoid use of ''.format

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -180,6 +180,12 @@ ODOO_MSGS = {
         'old-api7-method-defined',
         settings.DESC_DFLT
     ),
+    'R%d11' % settings.BASE_NOMODULE_ID: (
+        'Prefer "%(varname)"s over .format(). This is better for translation '
+        ' and clarity.',
+        'prefer-other-formatting',
+        settings.DESC_DFLT
+    ),
 }
 
 DFTL_MANIFEST_REQUIRED_KEYS = ['license']
@@ -281,9 +287,11 @@ class NoModuleChecker(BaseChecker):
 
     @utils.check_messages('translation-field', 'invalid-commit',
                           'method-compute', 'method-search', 'method-inverse',
-                          'sql-injection',
+                          'sql-injection', 'prefer-other-formatting',
                           )
     def visit_call(self, node):
+        if self.get_func_name(node.func) == 'format':
+            self.add_message('prefer-other-formatting', node=node)
         if node.as_string().lower().startswith('fields.'):
             args = misc.join_node_args_kwargs(node)
             for argument in args:

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -290,7 +290,9 @@ class NoModuleChecker(BaseChecker):
                           'sql-injection', 'prefer-other-formatting',
                           )
     def visit_call(self, node):
-        if self.get_func_name(node.func) == 'format':
+        node_infer = utils.safe_infer(node.func)
+        if utils.is_builtin_object(node_infer) and \
+                self.get_func_name(node.func) == 'format':
             self.add_message('prefer-other-formatting', node=node)
         if node.as_string().lower().startswith('fields.'):
             args = misc.join_node_args_kwargs(node)

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -43,6 +43,7 @@ EXPECTED_ERRORS = {
     'odoo-addons-relative-import': 4,
     'old-api7-method-defined': 2,
     'openerp-exception-warning': 3,
+    'prefer-other-formatting': 4,
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,
     'sql-injection': 6,

--- a/pylint_odoo/test_repo/pylint_deprecated_modules/openerp/__init__.py
+++ b/pylint_odoo/test_repo/pylint_deprecated_modules/openerp/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import osv  # pylint: disable=W0402
+_ = str


### PR DESCRIPTION
ASCII errors could be caused by use string ''.format
You could see the following cases:
`u'%s' % u'á'`  # without error
`'%s' % u'á'`  # without error

`u'{}'.format(u'á')`  # without error
`'{}'.format(u'á')`  # error
You will see the error:
`UnicodeEncodeError: 'ascii' codec can't encode character u'\xe1' in position 1: ordinal not in range(128)`

Similar case for
`'%(var)s' % {'var': u'á'}`  # without error
`'{var}'.format(var=u'á')`  # error

It's agree with our guideline https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#idioms
`Prefer % over .format(), prefer %(varname) instead of positional. This is better for translation and clarity.`