### PR TITLE
[FIX] rst-syntax-error: Skip unknown directives and roles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,8 @@ Example to test just odoo-lint case:
 
 If you have external files you can add them in ``examples`` folder to skip.
 
+For rst-syntax-error skip unknown directives
+
 
 .. |Build Status| image:: https://travis-ci.org/OCA/pylint-odoo.svg?branch=master
    :target: https://travis-ci.org/OCA/pylint-odoo

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -251,8 +251,11 @@ class ModuleChecker(misc.WrapperModuleChecker):
                 os.path.join(self.module_path, rst_file))
             for error in errors:
                 msg = error.full_message
-                res = re.search(r'No directive entry for "([\w|\-]+)"|'
-                                r'Unknown directive type "([\w|\-]+)"', msg)
+                res = re.search(
+                    r'No directive entry for "([\w|\-]+)"|'
+                    r'Unknown directive type "([\w|\-]+)"|'
+                    r'No role entry for "([\w|\-]+)"|'
+                    r'Unknown interpreted text role "([\w|\-]+)"', msg)
                 # TODO: Add support for sphinx directives after fix
                 # https://github.com/twolfson/restructuredtext-lint/issues/29
                 if res:

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -3,6 +3,7 @@
 
 import ast
 import os
+import re
 
 import astroid
 from pylint.checkers import utils
@@ -249,9 +250,17 @@ class ModuleChecker(misc.WrapperModuleChecker):
             errors = self.check_rst_syntax(
                 os.path.join(self.module_path, rst_file))
             for error in errors:
+                msg = error.full_message
+                res = re.search(r'No directive entry for "([\w|\-]+)"|'
+                                r'Unknown directive type "([\w|\-]+)"', msg)
+                # TODO: Add support for sphinx directives after fix
+                # https://github.com/twolfson/restructuredtext-lint/issues/29
+                if res:
+                    # Skip directive errors
+                    continue
                 self.msg_args.append((
                     "%s:%d" % (rst_file, error.line),
-                    error.full_message.strip('\n').replace('\n', '|')))
+                    msg.strip('\n').replace('\n', '|')))
         if self.msg_args:
             return False
         return True

--- a/pylint_odoo/test_repo/broken_module2/README.rst
+++ b/pylint_odoo/test_repo/broken_module2/README.rst
@@ -26,3 +26,11 @@ Developer's guide
 
    guides/concepts.rst
    guides/code_overview.rst
+
+******************
+Indices and tables
+******************
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pylint_odoo/test_repo/broken_module2/README.rst
+++ b/pylint_odoo/test_repo/broken_module2/README.rst
@@ -2,3 +2,27 @@ Test module 2
 =============
 
 This module was written to check the test lint
+
+
+*******
+Project
+*******
+
+.. toctree::
+   :maxdepth: 1
+
+   project/contribute
+   project/contributors
+   project/license
+   project/changes
+   project/roadmap
+
+*****************
+Developer's guide
+*****************
+
+.. toctree::
+   :maxdepth: 2
+
+   guides/concepts.rst
+   guides/code_overview.rst


### PR DESCRIPTION
- Fix https://github.com/OCA/pylint-odoo/issues/38

The best solution is add support for sphinx RST directives.
But we had problems from main libraries to get a parser, more info:
 - https://github.com/twolfson/restructuredtext-lint/issues/29
 - https://github.com/sphinx-doc/sphinx/issues/2922

Then for now we need to skip this type of errors and add a `TODO` if the issue is fixed.