### PR TITLE
[REF] requirements: Update version of pylint and astroid

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -191,9 +191,6 @@ class ModuleChecker(misc.WrapperModuleChecker):
                 'consider-merging-classes-inherited', node.lineno):
             return
         node_left = node.targets[0]
-        if not hasattr(astroid, 'ClassDef'):
-            # Compatibility with old pylint versions
-            astroid.ClassDef = astroid.Class
         if not isinstance(node_left, astroid.node_classes.AssName) or \
                 node_left.name not in ('_inherit', '_name') or \
                 not isinstance(node.value, astroid.node_classes.Const) or \
@@ -232,8 +229,6 @@ class ModuleChecker(misc.WrapperModuleChecker):
 
     def _get_odoo_module_imported(self, node):
         odoo_module = []
-        if not hasattr(astroid, 'ImportFrom'):
-            astroid.ImportFrom = astroid.From
         if isinstance(node, astroid.ImportFrom) and \
                 ('openerp.addons' in node.modname or
                  'odoo.addons' in node.modname):
@@ -316,8 +311,6 @@ class ModuleChecker(misc.WrapperModuleChecker):
         if isinstance(node.scope(), astroid.Module):
             package = node.modname
             self._check_imported_packages(node, package)
-
-    visit_from = visit_importfrom
 
     @utils.check_messages('odoo-addons-relative-import',
                           'missing-import-error',

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -319,8 +319,6 @@ class NoModuleChecker(BaseChecker):
             if is_bin_op or is_format:
                 self.add_message('sql-injection', node=node)
 
-    visit_callfunc = visit_call
-
     @utils.check_messages('manifest-required-author', 'manifest-required-key',
                           'manifest-deprecated-key')
     def visit_dict(self, node):
@@ -416,8 +414,6 @@ class NoModuleChecker(BaseChecker):
                first_args[2] in ['uid', 'user', 'user_id']:
                 self.add_message('old-api7-method-defined', node=node)
 
-    visit_function = visit_functiondef
-
     @utils.check_messages('openerp-exception-warning')
     def visit_importfrom(self, node):
         if node.modname == 'openerp.exceptions':
@@ -425,16 +421,12 @@ class NoModuleChecker(BaseChecker):
                 if import_name == 'Warning' and import_as_name != 'UserError':
                     self.add_message('openerp-exception-warning', node=node)
 
-    visit_from = visit_importfrom
-
     @utils.check_messages('class-camelcase')
     def visit_classdef(self, node):
         camelized = self.camelize(node.name)
         if camelized != node.name:
             self.add_message('class-camelcase', node=node,
                              args=(camelized, node.name))
-
-    visit_class = visit_classdef
 
     @utils.check_messages('attribute-deprecated')
     def visit_assign(self, node):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-pylint==1.4.4
-pylint-plugin-utils==0.2.3
-astroid==1.3.8
+astroid==1.4.8
+pylint==1.6.4
+pylint-plugin-utils==0.2.4
 docutils==0.12
 lxml>=2.3.2
 Pygments==2.0.2
 restructuredtext_lint==0.12.2
 isort==4.2.5
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,20 +4,21 @@ skip_missing_interpreters = true
 
 [base]
 deps =
-   pylint-plugin-utils==0.2.3
+   pylint-plugin-utils==0.2.4
    docutils==0.12
    lxml>=2.3.2
    Pygments==2.0.2
    restructuredtext_lint==0.12.2
+   isort==4.2.5
+   # Test deps
    coveralls
-   isort
 
 [testenv]
 deps =
-    py27-pylint14: astroid==1.4.6
-    py27-pylint14: pylint==1.5.6
-    py27-pylint20: git+https://github.com/PyCQA/astroid@461e016
-    py27-pylint20: git+https://github.com/PyCQA/pylint@0495355
+    py27-pylint14: astroid==1.4.8
+    py27-pylint14: pylint==1.6.4
+    py27-pylint20: git+https://github.com/PyCQA/astroid@9979615#egg=astroid
+    py27-pylint20: git+https://github.com/PyCQA/pylint@05cc9a7#egg=pylint
    {[base]deps}
 setenv =
     PYLINT_ODOO_STATS = {toxinidir}/.cprofile_{envname}


### PR DESCRIPTION
Update version of dependencies:
 - astroid==1.4.8
 - pylint==1.6.4
 - pylint-plugin-utils==0.2.4

For test use last sha:
 - https://github.com/PyCQA/astroid/commit/9979615
 - https://github.com/PyCQA/pylint/commit/05cc9a7


Useful in order to discuss new checks of pylint 1.6.4 from [MQT](https://github.com/oca/maintainer-quality-tools)

Fix https://github.com/OCA/pylint-odoo/pull/70