### PR TITLE
Adding isort dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ docutils==0.12
 lxml>=2.3.2
 Pygments==2.0.2
 restructuredtext_lint==0.12.2
+isort==4.2.5


### PR DESCRIPTION
When using the pylint_odoo plugin as part of the OCA's Maintainer Quality Tools it doesn't appear to be installing the isort library that pylint_odoo depends on which has meant that my linting jobs in Travis have been erroring with the following:

```
======== Testing test_pylint ========
Traceback (most recent call last):
  File "/home/travis/maintainer-quality-tools/travis/test_pylint", line 173, in <module>
    ] + extra_params_cmd, standalone_mode=False)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/maintainer-quality-tools/travis/run_pylint.py", line 104, in main
    extra_params=extra_params)
  File "/home/travis/maintainer-quality-tools/travis/run_pylint.py", line 75, in run_pylint
    pylint_res = pylint.lint.Run(cmd, exit=False)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pylint/lint.py", line 1242, in __init__
    linter.load_plugin_modules(self._plugins)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pylint/lint.py", line 498, in load_plugin_modules
    module = modutils.load_module_from_name(modname)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/astroid/modutils.py", line 137, in load_module_from_name
    return load_module_from_modpath(dotted_name.split('.'), path, use_sys)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/astroid/modutils.py", line 180, in load_module_from_modpath
    module = imp.load_module(curname, mp_file, mp_filename, mp_desc)
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pylint_odoo/__init__.py", line 2, in <module>
    from . import checkers
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pylint_odoo/checkers/__init__.py", line 1, in <module>
    from . import modules_odoo
  File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pylint_odoo/checkers/modules_odoo.py", line 8, in <module>
    import isort
ImportError: No module named isort
```

I'd like to add this dependency to the requirements.txt to prevent this from happening to others in the future