### PR TITLE
[IMP] manifest-version-format: Add valid_odoo_versions parameter

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -197,7 +197,10 @@ DFTL_METHOD_REQUIRED_SUPER = [
     'create', 'write', 'read', 'unlink', 'copy',
     'setUp', 'tearDown', 'default_get',
 ]
-DFTL_MANIFEST_VERSION_FORMAT = r"(\d+.\d+.\d+.\d+.\d+)"
+DFTL_VALID_ODOO_VERSIONS = [
+    '4.2', '5.0', '6.0', '6.1', '7.0', '8.0', '9.0', '10.0'
+]
+DFTL_MANIFEST_VERSION_FORMAT = r"(%(valid_odoo_versions)s).\d+.\d+.\d+"
 DFTL_CURSOR_EXPR = [
     'self.env.cr', 'self._cr',  # new api
     'self.cr',  # controllers and test
@@ -263,7 +266,9 @@ class NoModuleChecker(BaseChecker):
             'type': 'string',
             'metavar': '<string>',
             'default': DFTL_MANIFEST_VERSION_FORMAT,
-            'help': 'Regex to check version format in manifest file'
+            'help': 'Regex to check version format in manifest file. '
+            'Use "%(valid_odoo_versions)s" to check the parameter of '
+            '"valid_odoo_versions"'
         }),
         ('cursor_expr', {
             'type': 'csv',
@@ -276,6 +281,12 @@ class NoModuleChecker(BaseChecker):
             'metavar': '<comma separated values>',
             'default': DFTL_ODOO_EXCEPTIONS,
             'help': 'List of odoo exceptions separated by a comma.'
+        }),
+        ('valid_odoo_versions', {
+            'type': 'csv',
+            'metavar': '<comma separated values>',
+            'default': DFTL_VALID_ODOO_VERSIONS,
+            'help': 'List of valid odoo versions separated by a comma.'
         }),
     )
 
@@ -366,7 +377,7 @@ class NoModuleChecker(BaseChecker):
         if version_format and not formatrgx:
             self.add_message('manifest-version-format', node=node,
                              args=(version_format,
-                                   self.config.manifest_version_format,))
+                                   self.config.manifest_version_format_parsed))
 
     @utils.check_messages('api-one-multi-together',
                           'copy-wo-api-one', 'api-one-deprecated',
@@ -440,7 +451,10 @@ class NoModuleChecker(BaseChecker):
         return re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), string)
 
     def formatversion(self, string):
-        return re.match(self.config.manifest_version_format, string)
+        self.config.manifest_version_format_parsed = \
+            self.config.manifest_version_format % dict(
+                valid_odoo_versions='|'.join(self.config.valid_odoo_versions))
+        return re.match(self.config.manifest_version_format_parsed, string)
 
     def get_decorators_names(self, decorators):
         nodes = []


### PR DESCRIPTION
To force a valid version of odoo in the manifest version.

- [ ] After merge this one we need create a new PR for MQT to force the valid_odoo_versions as `VERSION` of the .travis.yml

Fix https://github.com/OCA/maintainer-quality-tools/issues/366