### PR TITLE
[FIX] missing-import-error: Updating libraries

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -132,10 +132,16 @@ DFLT_IMPORT_NAME_WHITELIST = [
     # self-odoo
     'odoo', 'openerp',
     # Known external packages of odoo
-    'PIL', 'babel', 'dateutil', 'decorator', 'docutils', 'faces',
-    'jinja2', 'ldap', 'lxml', 'mako', 'mock', 'odf', 'openid', 'passlib',
-    'pkg_resources', 'psycopg2', 'pyPdf', 'pychart', 'pytz', 'reportlab',
-    'requests', 'serial', 'simplejson', 'unittest2', 'usb', 'werkzeug', 'yaml',
+    'PIL', 'argparse', 'babel', 'dateutil',
+    'decorator', 'docutils', 'faces', 'feedparser',
+    'gdata', 'gevent', 'greenlet', 'jcconv', 'jinja2',
+    'ldap', 'lxml', 'mako', 'markupsafe', 'mock', 'odf',
+    'ofxparse', 'openid', 'passlib', 'pkg_resources',
+    'psutil', 'psycogreen', 'psycopg2', 'pyPdf', 'pychart',
+    'pydot', 'pyparsing', 'pytz', 'qrcode', 'reportlab',
+    'requests', 'serial', 'simplejson', 'six', 'suds',
+    'unittest2', 'usb', 'vatnumber', 'vobject', 'werkzeug',
+    'wsgiref', 'xlsxwriter', 'xlwt', 'yaml',
 ]
 
 


### PR DESCRIPTION
Updating libraries used from requirements.txt 

This libraries don't was detect them because are nested imported or not imported directly from odoo.

Example of library imported nested: [psutils](https://github.com/odoo/odoo/blob/8.0/requirements.txt#L20)
 - [psutils with try except ImportError](https://github.com/odoo/odoo/blob/d81258ab8e0dcb6c0df3a47ab8084ec99b7d3e24/openerp/http.py#L40-L43)

Example of library not used: [pyparsing](https://github.com/odoo/odoo/blob/8.0/requirements.txt#L25)

 - <img width="576" alt="screen shot 2016-10-14 at 7 41 07 am" src="https://cloud.githubusercontent.com/assets/6644187/19387700/89d92616-91e1-11e6-9b70-1b8857625232.png">


Fix https://github.com/OCA/maintainer-quality-tools/issues/374