### PR TITLE
[FIX] manifest-version-format: Support -e manifest-version-format only

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -330,8 +330,10 @@ class NoModuleChecker(BaseChecker):
             if is_bin_op or is_format:
                 self.add_message('sql-injection', node=node)
 
-    @utils.check_messages('manifest-required-author', 'manifest-required-key',
-                          'manifest-deprecated-key')
+    @utils.check_messages(
+        'license-allowed', 'manifest-author-string', 'manifest-deprecated-key',
+        'manifest-required-author', 'manifest-required-key',
+        'manifest-version-format')
     def visit_dict(self, node):
         if not os.path.basename(self.linter.current_file) in \
                 settings.MANIFEST_FILES \


### PR DESCRIPTION
If you enable just `manifest-version-format` is not working.

Example: 
 - `pylint --load-plugins=pylint_odoo -d all -e manifest-version-format module_with_bad_manifest_version` is not detected before of this fix.

After of this fix now is detected.