### PR TITLE
[FIX] manifest-version-format: Fix regex to use explicit dot instead of any char

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -200,7 +200,7 @@ DFTL_METHOD_REQUIRED_SUPER = [
 DFTL_VALID_ODOO_VERSIONS = [
     '4.2', '5.0', '6.0', '6.1', '7.0', '8.0', '9.0', '10.0'
 ]
-DFTL_MANIFEST_VERSION_FORMAT = r"(%(valid_odoo_versions)s).\d+.\d+.\d+"
+DFTL_MANIFEST_VERSION_FORMAT = r"(%(valid_odoo_versions)s)\.\d+\.\d+\.\d+"
 DFTL_CURSOR_EXPR = [
     'self.env.cr', 'self._cr',  # new api
     'self.cr',  # controllers and test


### PR DESCRIPTION
Currently the regex allow any char instead of just dot, because the regex `r"\d+."` the dot is a standard of regex to any char.

```bash
>>> import re
>>> bool(re.match(r'\d+.\d+', '8,0'))
True
>>> bool(re.match(r'\d+\.\d+', '8,0'))
False
>>> bool(re.match(r'\d+\.\d+', '8.0'))
True
```

Thanks @lasley in the following comment: https://github.com/OCA/maintainer-quality-tools/pull/375#issuecomment-253862702