### PR TITLE
[ADD] missing-return

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -101,6 +101,11 @@ ODOO_MSGS = {
         'method-required-super',
         settings.DESC_DFLT
     ),
+    'W%d10' % settings.BASE_NOMODULE_ID: (
+        'Missing `return` (`super` is used) in method %s.',
+        'missing-return',
+        settings.DESC_DFLT
+    ),
     'E%d01' % settings.BASE_NOMODULE_ID: (
         'The author key in the manifest file must be a string '
         '(with comma separated values)',
@@ -212,6 +217,9 @@ DFTL_ODOO_EXCEPTIONS = [
     'MissingError', 'QWebException', 'RedirectWarning', 'UserError',
     'ValidationError', 'Warning',
 ]
+DFTL_NO_MISSING_RETURN = [
+    '__init__', 'setUp', 'tearDown',
+]
 
 
 class NoModuleChecker(BaseChecker):
@@ -287,6 +295,13 @@ class NoModuleChecker(BaseChecker):
             'metavar': '<comma separated values>',
             'default': DFTL_VALID_ODOO_VERSIONS,
             'help': 'List of valid odoo versions separated by a comma.'
+        }),
+        ('no_missing_return', {
+            'type': 'csv',
+            'metavar': '<comma separated values>',
+            'default': DFTL_NO_MISSING_RETURN,
+            'help': 'List of valid missing return method names, '
+            'separated by a comma.'
         }),
     )
 
@@ -384,6 +399,7 @@ class NoModuleChecker(BaseChecker):
     @utils.check_messages('api-one-multi-together',
                           'copy-wo-api-one', 'api-one-deprecated',
                           'method-required-super', 'old-api7-method-defined',
+                          'missing-return',
                           )
     def visit_functiondef(self, node):
         """Check that `api.one` and `api.multi` decorators not exists together
@@ -426,6 +442,22 @@ class NoModuleChecker(BaseChecker):
                first_args[1] in ['cr', 'cursor'] and \
                first_args[2] in ['uid', 'user', 'user_id']:
                 self.add_message('old-api7-method-defined', node=node)
+
+        there_is_super = False
+        for stmt in node.nodes_of_class(astroid.Call):
+            func = stmt.func
+            if isinstance(func, astroid.Name) and func.name == 'super':
+                there_is_super = True
+                break
+        there_is_return = False
+        for stmt in node.nodes_of_class(astroid.Return,
+                                        skip_klass=(astroid.FunctionDef,
+                                                    astroid.ClassDef)):
+            there_is_return = True
+            break
+        if there_is_super and not there_is_return and \
+           node.name not in self.config.no_missing_return:
+            self.add_message('missing-return', node=node, args=(node.name))
 
     @utils.check_messages('openerp-exception-warning')
     def visit_importfrom(self, node):

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -41,6 +41,7 @@ EXPECTED_ERRORS = {
     'missing-manifest-dependency': 2,
     'missing-newline-extrafiles': 3,
     'missing-readme': 1,
+    'missing-return': 1,
     'no-utf8-coding-comment': 3,
     'odoo-addons-relative-import': 4,
     'old-api7-method-defined': 2,

--- a/pylint_odoo/test_repo/broken_module/pylint_oca_broken.py
+++ b/pylint_odoo/test_repo/broken_module/pylint_oca_broken.py
@@ -21,6 +21,13 @@ class UseUnusedImport(object):
     def method1(self):
         return UserError, OtherName, Warning, AE, ValidationError, UserError2
 
+    def inherited_method(self):
+        # Missing return()
+        super(UseUnusedImport, self).inherited_method()
+
+    def write(self):
+        return super(UseUnusedImport, self).write()
+
 
 class ApiOne(object):
     @api.one


### PR DESCRIPTION
If you use call a `super` method then you will need return the original
value.
If you want overwrite a original method then you need add documentation
of why and add a `pylint: disable=missing-return`