### PR TITLE
[FIX] test: Never use global into test

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -26,16 +26,6 @@ def get_plugin_msgs(pylint_run_res):
     return all_plugin_msgs
 
 
-def get_sum_fails(pylint_stats):
-    """Get a sum of all fails.
-    :param pylint_stats: Object returned by pylint.run method.
-    :return: Integer with sum of all errors found.
-    """
-    return sum([
-        pylint_stats['by_msg'][msg]
-        for msg in pylint_stats['by_msg']])
-
-
 def join_node_args_kwargs(node):
     """Method to join args and keywords
     :param node: node to get args and keywords


### PR DESCRIPTION
- Now we have a `assertEqual(dict1, dict2)` then a sum of checkers is not required.
- `global VARIABLE` is not a good idea from unittest, because could affect the result of other tests.
- Convert comments to docstring
- Clean code