### PR TITLE
[ADD] renamed-field-parameter: detect deprecated field values (digits_compute, select) (#91)

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -348,7 +348,7 @@ class NoModuleChecker(BaseChecker):
         >>> self.colon_list_to_dict(['colon:list', 'empty_key:'])
         {'colon': 'list', 'empty_key': ''}
         """
-        return dict([item.split(":") for item in colon_list])
+        return dict(item.split(":") for item in colon_list)
 
     @utils.check_messages('translation-field', 'invalid-commit',
                           'method-compute', 'method-search', 'method-inverse',
@@ -362,6 +362,7 @@ class NoModuleChecker(BaseChecker):
                 argument_aux = argument
                 if isinstance(argument, astroid.Keyword):
                     argument_aux = argument.value
+                    deprecated = self.config.deprecated_field_parameters
                     if argument.arg in ['compute', 'search', 'inverse'] and \
                             isinstance(argument_aux, astroid.Const) and \
                             isinstance(argument_aux.value, string_types) and \
@@ -369,14 +370,10 @@ class NoModuleChecker(BaseChecker):
                                 '_' + argument.arg + '_'):
                         self.add_message('method-' + argument.arg,
                                          node=argument_aux)
-                    elif (argument.arg in
-                            self.config.deprecated_field_parameters):
-                        new_param = self.config.deprecated_field_parameters[
-                            argument.arg
-                        ]
+                    elif (argument.arg in deprecated):
                         self.add_message(
                             'renamed-field-parameter', node=node,
-                            args=(argument.arg, new_param)
+                            args=(argument.arg, deprecated[argument.arg])
                         )
                 if isinstance(argument_aux, astroid.CallFunc) and \
                         isinstance(argument_aux.func, astroid.Name) and \

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -54,6 +54,7 @@ EXPECTED_ERRORS = {
     'use-vim-comment': 1,
     'wrong-tabs-instead-of-spaces': 2,
     'xml-syntax-error': 2,
+    'renamed-field-parameter': 2,
 }
 
 

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -46,6 +46,18 @@ class TestModel(models.Model):
         copy=True,
     )
 
+    my_ok_field = fields.Float(
+        digits=(6, 6),  # OK: Valid field parameter
+        index=True,  # OK: Valid field parameter
+        help="My ok field",
+    )
+
+    my_ko_field = fields.Float(
+        digits_compute=lambda cr: (6, 6),  # Deprecated field parameter
+        select=True,  # Deprecated field parameter
+        help="My ko field",
+    )
+
     def my_method1(self, variable1):
         #  Shouldn't show error of field-argument-translate
         self.my_method2(_('hello world'))


### PR DESCRIPTION
Add check to detect deprecated/renamed parameters in a field constructor.

Checking the parameters specified in: https://github.com/odoo/odoo/blob/10.0/odoo/fields.py#L29

![image](https://cloud.githubusercontent.com/assets/8657959/21488025/38896c86-cbb0-11e6-98a3-8804631b9bc7.png)
