### PR TITLE
[ADD] eval-referenced: Detects if a "eval" is referenced (without call it)

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -186,6 +186,11 @@ ODOO_MSGS = {
         'old-api7-method-defined',
         settings.DESC_DFLT
     ),
+    'W%d11' % settings.BASE_NOMODULE_ID: (
+        '"eval" referenced detected.',
+        'eval-referenced',
+        settings.DESC_DFLT
+    ),
 }
 
 DFTL_MANIFEST_REQUIRED_KEYS = ['license']
@@ -482,6 +487,16 @@ class NoModuleChecker(BaseChecker):
             if node_left.name in self.config.attribute_deprecated:
                 self.add_message('attribute-deprecated',
                                  node=node_left, args=(node_left.name,))
+
+    @utils.check_messages('eval-referenced')
+    def visit_name(self, node):
+        """Detect when a "bad" built-in is referenced."""
+        node_infer = utils.safe_infer(node)
+        if not utils.is_builtin_object(node_infer):
+            # Skip not builtin objects
+            return
+        if node_infer.name == 'eval':
+            self.add_message('eval-referenced', node=node)
 
     def camelize(self, string):
         return re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), string)

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -53,6 +53,7 @@ EXPECTED_ERRORS = {
     'translation-required': 4,
     'use-vim-comment': 1,
     'wrong-tabs-instead-of-spaces': 2,
+    'eval-referenced': 5,
     'xml-syntax-error': 2,
 }
 

--- a/pylint_odoo/test_repo/no_odoo_module/__init__.py
+++ b/pylint_odoo/test_repo/no_odoo_module/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import myfile
+from . import eval_used

--- a/pylint_odoo/test_repo/no_odoo_module/eval_used.py
+++ b/pylint_odoo/test_repo/no_odoo_module/eval_used.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
 
-def func2(param):
+def eval_from_param(param):
     """eval used from param"""
     param("c = 2")
 
 
-def func3():
+def eval_from_other():
     """eval used from many ways"""
     my_dict = {
         'my_eval': eval,  # [eval-used]
@@ -16,5 +16,5 @@ def func3():
     my_var = eval  # [eval-used]
     # inferred case
     my_var('d = 3')  # [eval-used]
-    func2(eval)  # [eval-used]
+    eval_from_param(eval)  # [eval-used]
     return my_dict, my_list

--- a/pylint_odoo/test_repo/no_odoo_module/eval_used.py
+++ b/pylint_odoo/test_repo/no_odoo_module/eval_used.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+
+def func2(param):
+    """eval used from param"""
+    param("c = 2")
+
+
+def func3():
+    """eval used from many ways"""
+    my_dict = {
+        'my_eval': eval,  # [eval-used]
+    }
+    my_list = [eval]  # [eval-used]
+
+    my_var = eval  # [eval-used]
+    # inferred case
+    my_var('d = 3')  # [eval-used]
+    func2(eval)  # [eval-used]
+    return my_dict, my_list


### PR DESCRIPTION
**Detects referenced and inferred cases**

```
def func2(param): 
       param("c = 2")

 def func3():
     my_dict = {
         'my_eval': eval,  # [eval-referenced]
     }
     my_list = [eval]  # [eval-referenced]
 
     my_var = eval  # [eval-referenced]
     # inferred case
     my_var('d = 3')  # [eval-referenced]
     func2(eval)  # [eval-referenced]
     return my_dict, my_list
```