### PR TITLE
[IMP] pylint-odoo: Adding support for parameters --ignore and --ignore-patterns

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -151,6 +151,27 @@ class MainTest(unittest.TestCase):
         real_errors = pylint_res.linter.stats['by_msg']
         self.assertEqual(real_errors.items(), [('deprecated-module', 4)])
 
+    def test_50_ignore(self):
+        """Test --ignore parameter """
+        extra_params = ['--ignore=test_module/res_users.xml',
+                        '--disable=all',
+                        '--enable=deprecated-openerp-xml-node']
+        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        real_errors = pylint_res.linter.stats['by_msg']
+        self.assertEqual(real_errors.items(),
+                         [('deprecated-openerp-xml-node', 4)])
+
+    def test_60_ignore_patternls(self):
+        """Test --ignore-patterns parameter """
+        extra_params = ['--ignore-patterns='
+                        '.*\/test_module\/*\/.*xml$',
+                        '--disable=all',
+                        '--enable=deprecated-openerp-xml-node']
+        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        real_errors = pylint_res.linter.stats['by_msg']
+        self.assertEqual(real_errors.items(),
+                         [('deprecated-openerp-xml-node', 3)])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
pylint supports the following parameters:

- `--ignore=<file>[,<file>...]`
- `--ignore-patterns=<pattern>[,<pattern>...]`

But pylint-odoo is not using for ignore them from custom search files methods.
We are searching files: js, md, rst...
And we need skip them too if this parameters is defined.
