### PR TITLE
[ADD] except-pass: Emit message If a except:pass is used (OCA/#252)

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -117,6 +117,12 @@ ODOO_MSGS = {
         'missing-manifest-dependency',
         settings.DESC_DFLT
     ),
+    'W%d38' % settings.BASE_OMODULE_ID: (
+        'pass into block except. '
+        'If you really need to use the pass consider logging that exception',
+        'except-pass',
+        settings.DESC_DFLT
+    ),
     'W%d37' % settings.BASE_OMODULE_ID: (
         '%s The xml attribute is missing the translation="off" tag %s',
         'xml-attribute-translatable',
@@ -350,6 +356,15 @@ class ModuleChecker(misc.WrapperModuleChecker):
         for name, _ in node.names:
             if isinstance(node.scope(), astroid.Module):
                 self._check_imported_packages(node, name)
+
+    @utils.check_messages('except-pass')
+    def visit_tryexcept(self, node):
+        """Visit block try except"""
+        for handler in node.handlers:
+            if (not handler.name and
+                    len(handler.body) == 1 and
+                    isinstance(handler.body[0], astroid.node_classes.Pass)):
+                self.add_message('except-pass', node=handler)
 
     def _check_rst_syntax_error(self):
         """Check if rst file there is syntax error

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -58,6 +58,7 @@ EXPECTED_ERRORS = {
     'wrong-tabs-instead-of-spaces': 2,
     'eval-referenced': 5,
     'xml-syntax-error': 2,
+    'except-pass': 3,
     'attribute-string-redundant': 33,
     'renamed-field-parameter': 2,
     'xml-attribute-translatable': 1,

--- a/pylint_odoo/test_repo/test_module/except_pass.py
+++ b/pylint_odoo/test_repo/test_module/except_pass.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Test Except Pass usage"""
+
+
+class TestExceptPass(object):
+    """Test Except Pass class """
+
+    def test_method(self):
+        """Test method """
+        try:
+            raise Exception('Exception')
+        except Exception:  # except-pass
+            pass
+
+    def test_2_method(self):
+        """Test 2 method """
+        try:
+            raise Exception('Exception')
+        except Exception:
+            pass
+            print('Exception')
+
+    def test_3_method(self):
+        """Test 3 method """
+        try:
+            raise Exception('Exception')
+        except Exception as exception:
+            pass
+        if exception:
+            pass
+
+    def test_4_method(self):
+        try:
+            raise Exception('Exception')
+        except Exception, userError:
+            pass
+        if userError:
+            pass
+
+    def test_5_method(self):
+        try:
+            raise Exception('Exception')
+        except (Exception, IndexError) as exception:
+            pass
+        if exception:
+            pass
+
+    def test_6_method(self):
+        try:
+            raise Exception('Exception')
+        except (Exception, IndexError):  # except-pass
+            pass
+
+    def test_7_method(self):
+        try:
+            raise Exception('Exception')
+        except (Exception, IndexError, NameError), exception:
+            pass
+        except Exception:  # except-pass
+            pass
+        if exception:
+            pass

--- a/pylint_odoo/test_repo/test_module/except_pass.py
+++ b/pylint_odoo/test_repo/test_module/except_pass.py
@@ -6,14 +6,13 @@ class TestExceptPass(object):
     """Test Except Pass class """
 
     def test_method(self):
-        """Test method """
         try:
             raise Exception('Exception')
         except Exception:  # except-pass
             pass
 
     def test_2_method(self):
-        """Test 2 method """
+        """This pass is skip for body of except has more than one line """
         try:
             raise Exception('Exception')
         except Exception:
@@ -21,7 +20,7 @@ class TestExceptPass(object):
             print('Exception')
 
     def test_3_method(self):
-        """Test 3 method """
+        """This pass is skip for the exception is assigned"""
         try:
             raise Exception('Exception')
         except Exception as exception:


### PR DESCRIPTION
The `pass` into block except is not a good practice!

  By including the `pass` we assume that our algorithm can continue to function after the exception occurred

  If you really need to use the `pass` consider logging that exception

  ```python
      try:
          sentences
      except:
          pass
         _logger.debug('Why the exception is safe....', exc_info=1))
  ```

fix https://github.com/OCA/maintainer-tools/pull/252