### PR TITLE
[REF] .travis.yml: Renamed flake8 error from F999 to F601

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     - pip install tox
 
 script:
-    - flake8 --ignore=F999 --exclude=__init__.py .
+    - flake8 --ignore=F601 --exclude=__init__.py .
     - tox -e $TOXENV,profile-stats
 
 after_success:


### PR DESCRIPTION
Regression flake8 error because renamed of error from original tool
 - https://github.com/OCA/pylint-odoo/pull/86/commits/e743df26c15ebadd865c2764856bff9dce78e14b