### PR TITLE
[FIX] fields: Validate a assign directly from root class

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -375,7 +375,9 @@ class NoModuleChecker(BaseChecker):
                           'renamed-field-parameter'
                           )
     def visit_call(self, node):
-        if node.as_string().lower().startswith('fields.'):
+        if 'fields' == self.get_func_lib(node.func) and \
+                isinstance(node.parent, astroid.Assign) and \
+                isinstance(node.parent.parent, astroid.ClassDef):
             args = misc.join_node_args_kwargs(node)
             index = 0
             field_name = ''
@@ -606,6 +608,12 @@ class NoModuleChecker(BaseChecker):
         func_name = isinstance(node, astroid.Name) and node.name or \
             isinstance(node, astroid.Getattr) and node.attrname or ''
         return func_name
+
+    def get_func_lib(self, node):
+        if isinstance(node, astroid.Getattr) and \
+                isinstance(node.expr, astroid.Name):
+            return node.expr.name
+        return ""
 
     @utils.check_messages('translation-required')
     def visit_raise(self, node):

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -375,9 +375,9 @@ class NoModuleChecker(BaseChecker):
                           'renamed-field-parameter'
                           )
     def visit_call(self, node):
-        if 'fields' == self.get_func_lib(node.func) and \
-                isinstance(node.parent, astroid.Assign) and \
-                isinstance(node.parent.parent, astroid.ClassDef):
+        if ('fields' == self.get_func_lib(node.func) and
+                isinstance(node.parent, astroid.Assign) and
+                isinstance(node.parent.parent, astroid.ClassDef)):
             args = misc.join_node_args_kwargs(node)
             index = 0
             field_name = ''

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -51,9 +51,6 @@ class TestModel(models.Model):
 
     # This is a inherit overwrite field then don't should show errors related
     # with creation of fields.
-    field_state_overwrite = fields.Selection(
-        selection_add=[('new_item', 'New Item')])
-
     def method_date(self):
         date = fields.Date.to_string(
             fields.Datetime.context_timestamp(self,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -11,6 +11,9 @@ import openerp.addons.broken_module as broken_module2
 import openerp.addons.broken_module.broken_model as broken_model2
 
 
+other_field = fields.Char()
+
+
 def function_no_method():
     return broken_model1, broken_module1, broken_module2, broken_model2
 
@@ -45,6 +48,18 @@ class TestModel(models.Model):
         'Other Field2',
         copy=True,
     )
+
+    # This is a inherit overwrite field then don't should show errors related
+    # with creation of fields.
+    field_state_overwrite = fields.Selection(
+        selection_add=[('new_item', 'New Item')])
+
+    def method_date(self):
+        date = fields.Date.to_string(
+            fields.Datetime.context_timestamp(self,
+                                              timestamp=fields.Datetime.now())
+        )
+        return date
 
     my_ok_field = fields.Float(
         "My correctly named field",


### PR DESCRIPTION
Avoid false messages if a variable `fields` is used from other side different to assign new columns for odoo classes

Referring to https://github.com/Vauxoo/pylint-odoo/issues/52