### PR TITLE
[IMP] sql-injection: support new cases and ignore some false positives

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -51,7 +51,7 @@ EXPECTED_ERRORS = {
     'openerp-exception-warning': 3,
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,
-    'sql-injection': 6,
+    'sql-injection': 15,
     'translation-field': 2,
     'translation-required': 4,
     'use-vim-comment': 1,


### PR DESCRIPTION
Improve the detection of possible SQL injection vectors by adding support for:
- executemany()
- queries built using the "+" operator
- queries built before the call to execute/executemany

Ignore queries built with private attributes (e.g.: self._table).