### PR TITLE
[REF] jslint: Enable no-comma-dangle check

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -147,7 +147,7 @@
     "brace-style": "error",
     "callback-return": "error",
     "camelcase": "off",
-    "comma-dangle": "off",
+    "comma-dangle": "error",
     "comma-spacing": "off",
     "comma-style": "error",
     "complexity": [


### PR DESCRIPTION
Fix https://github.com/OCA/pylint-odoo/issues/126

More info about: http://eslint.org/docs/rules/no-comma-dangle