### PR TITLE
[FIX] jslintrc: Remove deprecated ecmaFeatures key

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -242,6 +242,5 @@
     "yield-star-spacing": "off",
     "yoda": "error"
   },
-  "parserOptions": {},
-  "ecmaFeatures": {}
+  "parserOptions": {}
 }


### PR DESCRIPTION
The ecmaFeatures waas deprecated for 2.0.0 version

More info about:
http://eslint.org/docs/user-guide/migrating-to-2.0.0#language-options

This FIX the following error: `ESLint configuration is invalid: - Unexpected top-level property "ecmaFeatures".` for recent builds: https://travis-ci.org/OCA/pylint-odoo/jobs/242118234#L633