### PR TITLE
[IMP] pylint_odoo: Skip pylint check on one xml file

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -3,6 +3,7 @@ import csv
 import os
 import re
 import subprocess
+import inspect
 
 from lxml import etree
 from pylint.checkers import BaseChecker
@@ -209,7 +210,7 @@ class WrapperModuleChecker(BaseChecker):
         if not fext.startswith('.'):
             fext = '.' + fext
         fext = fext.lower()
-        fnames = self.ext_files.get(fext, [])
+        fnames = self._skip_files_ext(fext, self.ext_files.get(fext, []))
         for fname in list(fnames):
             dirnames = os.path.dirname(fname).split(os.sep)
             for dirname_to_skip in dirnames_to_skip:
@@ -221,6 +222,49 @@ class WrapperModuleChecker(BaseChecker):
             fnames = [  # pragma: no cover
                 os.path.join(self.module_path, fname)
                 for fname in fnames]
+        return fnames
+
+    def _skip_files_ext(self, fext, fnames):
+        """Detected inside the resource the skip message
+        Eg: '<!-- pylint-odoo:disable=deprecated-data-xml-node -->'
+        inside the xml resource"""
+        if fext != '.xml':
+            return fnames
+        info_called = [item[3] for item in inspect.stack() if
+                       'modules_odoo' in item[1]]
+        method_called = (info_called[0].replace(
+            '_check_', '').replace('_', '-') if info_called else False)
+        if method_called:
+            for fname in list(fnames):
+                full_name = os.path.join(self.module_path, fname)
+                if not os.path.isfile(full_name):
+                    continue
+
+                class PylintCommentTarget(object):
+                    def __init__(self):
+                        self.comments = []
+
+                    def comment(self, text):
+                        match = re.search(
+                            r'(pylint:disable=|pylint: disable=|'
+                            'pylint : disable=)', text)
+                        if match:
+                            text = match.re.split(text)[-1].replace(
+                                '_', '-').strip()
+                            self.comments.extend([item.strip() for item in
+                                                  text.split(',')])
+
+                    def close(self):
+                        return self.comments
+
+                parser = etree.XMLParser(target=PylintCommentTarget())
+                try:
+                    skips = etree.parse(open(full_name), parser)
+                except etree.XMLSyntaxError:
+                    skips = []
+                    pass
+                if method_called in skips and fname in fnames:
+                    fnames.remove(fname)
         return fnames
 
     def check_rst_syntax(self, fname):
@@ -313,6 +357,10 @@ class WrapperModuleChecker(BaseChecker):
         :return: List of lxml `record` nodes
             If there is syntax error return []
         """
+        xml_file = self._skip_files_ext('.xml', [xml_file])
+        if not xml_file:
+            return []
+        xml_file = xml_file[0]
         if model is None:
             model_filter = ''
         else:

--- a/pylint_odoo/test_repo/broken_module/__openerp__.py
+++ b/pylint_odoo/test_repo/broken_module/__openerp__.py
@@ -9,7 +9,10 @@
     'data': [
         'model_view.xml', 'model_view2.xml', 'model_view_odoo.xml',
         'model_view_odoo2.xml',
-        'file_no_exist.xml'
+        'file_no_exist.xml',
+        'skip_xml_check.xml',
+        'skip_xml_check_2.xml',
+        'skip_xml_check_3.xml'
     ],
     'demo': ['demo/duplicated_id_demo.xml', 'file_no_exist.xml'],
     'test': ['file_no_exist.yml'],

--- a/pylint_odoo/test_repo/broken_module/skip_xml_check.xml
+++ b/pylint_odoo/test_repo/broken_module/skip_xml_check.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- pylint:disable=deprecated-data-xml-node, duplicate-xml-record-id -->
+<odoo>
+    <data>
+        <record id="view_model_form80" model="ir.ui.view">
+            <field name="name">view.model.form80</field>
+            <field name="model">test.model</field>
+        </record>
+        <record id="view_model_form80" model="ir.ui.view">
+            <field name="name">view.model.form80</field>
+            <field name="model">test.model</field>
+        </record>
+    </data>
+</odoo>

--- a/pylint_odoo/test_repo/broken_module/skip_xml_check_2.xml
+++ b/pylint_odoo/test_repo/broken_module/skip_xml_check_2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp> <!-- pylint: disable=deprecated-openerp-xml-node -->
+    <data>
+    </data>
+</openerp>

--- a/pylint_odoo/test_repo/broken_module/skip_xml_check_3.xml
+++ b/pylint_odoo/test_repo/broken_module/skip_xml_check_3.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- pylint : disable=deprecated-data-xml-node,
+                    duplicate-xml-record-id -->
+<odoo>
+    <data>
+        <record id="view_model_form80" model="ir.ui.view">
+            <field name="name">view.model.form80</field>
+            <field name="model">test.model</field>
+        </record>
+        <record id="view_model_form80" model="ir.ui.view">
+            <field name="name">view.model.form80</field>
+            <field name="model">test.model</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This PR adding the functionality to skip xml resource like `pylint: disable=CHECK` the `CHECK` should be the name of the check, is not supported the number of the pylint check

This functionality only support `xml` files, one example of use is 

```xml
<?xml version="1.0" encoding="utf-8"?>
<!-- pylint:disable=deprecated-data-xml-node -->
<odoo>
    <data>
        ...
    </data>
</odoo>
```

Fix https://github.com/OCA/pylint-odoo/issues/132