### PR TITLE
[ADD] website-manifest-key-not-valid-uri: For validate if the website into manifest is valid URI

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -63,6 +63,7 @@ EXPECTED_ERRORS = {
     'renamed-field-parameter': 2,
     'deprecated-data-xml-node': 5,
     'resource-not-exist': 3,
+    'website-manifest-key-not-valid-uri': 1
 }
 
 

--- a/pylint_odoo/test_repo/broken_module/__openerp__.py
+++ b/pylint_odoo/test_repo/broken_module/__openerp__.py
@@ -5,6 +5,7 @@
     'author': 'Many People',  # Missing oca author
     'description': 'Should be a README.rst file',
     'version': '1.0',
+    'website': 'https://odoo-community.org',
     'depends': ['base'],
     'data': [
         'model_view.xml', 'model_view2.xml', 'model_view_odoo.xml',

--- a/pylint_odoo/test_repo/broken_module2/__openerp__.py
+++ b/pylint_odoo/test_repo/broken_module2/__openerp__.py
@@ -3,6 +3,7 @@
     'name': 'Broken module 2 for tests',
     'license': 'unknow license',  # unknow license
     'author': 'Other,Odoo Community Association (OCA)',  # Missing oca author
+    'website': 'https://odoo-community.org,https://odoo.com',
     'version': '1.0',
     'depends': ['base'],
     'data': [],

--- a/pylint_odoo/test_repo/broken_module3/__openerp__.py
+++ b/pylint_odoo/test_repo/broken_module3/__openerp__.py
@@ -3,6 +3,7 @@
     'name': 'Broken module 3 for tests',
     'license': 'AGPL-3',
     'author': ['Other', 'Odoo Community Association (OCA)'],  # expected string
+    'website': 'htt://odoo-community.com',
     'version': '8.0.1.0.0',
     'depends': ['base'],
     'data': [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Pygments==2.0.2
 restructuredtext_lint==0.12.2
 isort==4.2.5
 whichcraft
+rfc3986


### PR DESCRIPTION
This modification validate the website key into the manifest file using the `rfc3986` library

If the website contains `,` is considered a url bad formatted

Fix https://github.com/OCA/pylint-odoo/issues/121