### PR TITLE
[ADD] pylint-odoo: Adding new check unnecessary-attribute-noupdate

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -744,14 +744,14 @@ class ModuleChecker(misc.WrapperModuleChecker):
             nodes = []
             doc = self.parse_xml(os.path.join(self.module_path, xml_file))
             odoo_nodes = doc.xpath("/odoo") \
-                if not isinstance(doc, basestring) else []
+                if not isinstance(doc, string_types) else []
             children = ([item for item in odoo_nodes[0].getchildren()
                          if item.tag != 'data'] if odoo_nodes else [])
             if len(children) >= 1:
                 continue
             for xpath in ("/odoo/data[@noupdate='0']", "/odoo[@noupdate='0']"):
                 nodes.extend(doc.xpath(xpath)
-                             if not isinstance(doc, basestring) else [])
+                             if not isinstance(doc, string_types) else [])
             for node in nodes:
                 lineno = node.sourceline
                 self.msg_args.append(("%s:%s" % (xml_file, lineno)))

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -150,6 +150,12 @@ ODOO_MSGS = {
         'character-not-valid-in-resource-link',
         settings.DESC_DFLT
     ),
+    'W%d41' % settings.BASE_OMODULE_ID: (
+        '%s The attribute noupdate in <odoo noupdate="0">/<data noupdate="0"> '
+        'is unnecessary because the default value is zero',
+        'unnecessary-attribute-noupdate',
+        settings.DESC_DFLT
+    ),
 }
 
 
@@ -723,6 +729,25 @@ class ModuleChecker(misc.WrapperModuleChecker):
                                    if odoo_nodes else ([], []))
             if len(children) == 1 and len(data_node) == 1:
                 lineno = odoo_nodes[0].sourceline
+                self.msg_args.append(("%s:%s" % (xml_file, lineno)))
+        if self.msg_args:
+            return False
+        return True
+
+    def _check_unnecessary_attribute_noupdate(self):
+        """Check unnecessary noupdate attribute
+        <odoo noupdate="0">/<data noupdate="0">
+        :return: False if found noupdate="0" in xml """
+        xml_files = self.filter_files_ext('xml')
+        self.msg_args = []
+        for xml_file in xml_files:
+            doc = self.parse_xml(os.path.join(self.module_path, xml_file))
+            nodes = []
+            for xpath in ("/odoo/data[@noupdate='0']", "/odoo[@noupdate='0']"):
+                nodes.extend(doc.xpath(xpath)
+                             if not isinstance(doc, basestring) else [])
+            for node in nodes:
+                lineno = node.sourceline
                 self.msg_args.append(("%s:%s" % (xml_file, lineno)))
         if self.msg_args:
             return False

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -741,8 +741,14 @@ class ModuleChecker(misc.WrapperModuleChecker):
         xml_files = self.filter_files_ext('xml')
         self.msg_args = []
         for xml_file in xml_files:
-            doc = self.parse_xml(os.path.join(self.module_path, xml_file))
             nodes = []
+            doc = self.parse_xml(os.path.join(self.module_path, xml_file))
+            odoo_nodes = doc.xpath("/odoo") \
+                if not isinstance(doc, basestring) else []
+            children = ([item for item in odoo_nodes[0].getchildren()
+                         if item.tag != 'data'] if odoo_nodes else [])
+            if len(children) >= 1:
+                continue
             for xpath in ("/odoo/data[@noupdate='0']", "/odoo[@noupdate='0']"):
                 nodes.extend(doc.xpath(xpath)
                              if not isinstance(doc, basestring) else [])

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -68,6 +68,7 @@ EXPECTED_ERRORS = {
     'resource-not-exist': 3,
     'website-manifest-key-not-valid-uri': 1,
     'character-not-valid-in-resource-link': 2,
+    'unnecessary-attribute-noupdate': 2,
 }
 
 

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -62,7 +62,7 @@ EXPECTED_ERRORS = {
     'except-pass': 3,
     'attribute-string-redundant': 33,
     'renamed-field-parameter': 2,
-    'deprecated-data-xml-node': 5,
+    'deprecated-data-xml-node': 4,
     'xml-deprecated-tree-attribute': 3,
     'xml-deprecated-qweb-directive': 2,
     'resource-not-exist': 3,

--- a/pylint_odoo/test_repo/broken_module2/tests/data/odoo_data_noupdate_0.xml
+++ b/pylint_odoo/test_repo/broken_module2/tests/data/odoo_data_noupdate_0.xml
@@ -2,4 +2,6 @@
 <odoo>
     <data noupdate="0">
     </data>
+    <data noupdate="1">
+    </data>
 </odoo>

--- a/pylint_odoo/test_repo/broken_module2/tests/data/odoo_data_noupdate_0_2.xml
+++ b/pylint_odoo/test_repo/broken_module2/tests/data/odoo_data_noupdate_0_2.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+    </data>
+    <record>
+    </record>
+</odoo>


### PR DESCRIPTION
This check detected the unnecessary noupdate attribute `<odoo noupdate=0>/<data noupdate=0>` because the default value of attribute no update is zero

Example of the detected code 

```xml
<?xml version="1.0" encoding="utf-8"?>                                          
<odoo noupdate="0">
    ...
</odoo>    
```
```xml
<?xml version="1.0" encoding="utf-8"?>                                          
<odoo>
    <data noupdate="0">
    ...
    </data>
</odoo>    
```