### PR TITLE
[REF] cache: Cache other extension files just if is a odoo module

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -96,8 +96,8 @@ class WrapperModuleChecker(BaseChecker):
                     self.ext_files.setdefault(fext, []).append(fname_rel)
 
     def set_caches(self):
-        # TODO: Validate if is a odoo module before and has checks enabled
-        self.set_ext_files()
+        if self.odoo_node:
+            self.set_ext_files()
 
     def clear_caches(self):
         self.ext_files = None


### PR DESCRIPTION
Clean [TODO comment](https://github.com/OCA/pylint-odoo/blob/128d018791d2e74b6fbd9c5db19b0024c7f9e92b/pylint_odoo/misc.py#L99)

Currently if we have a big python project using pylint-odoo (non odoo module) is too slow because try get all files of the project.