### PR TITLE
[IMP] missing-return: Skip missing return if function is a generator

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -615,7 +615,8 @@ class NoModuleChecker(BaseChecker):
             there_is_return = True
             break
         if there_is_super and not there_is_return and \
-           node.name not in self.config.no_missing_return:
+                not node.is_generator() and \
+                node.name not in self.config.no_missing_return:
             self.add_message('missing-return', node=node, args=(node.name))
 
     @utils.check_messages('openerp-exception-warning')

--- a/pylint_odoo/test_repo/broken_module/pylint_oca_broken.py
+++ b/pylint_odoo/test_repo/broken_module/pylint_oca_broken.py
@@ -25,6 +25,12 @@ class UseUnusedImport(object):
         # Missing return()
         super(UseUnusedImport, self).inherited_method()
 
+    def inherited_method2(self):
+        # Missing return(), however this is a generator.
+        for i in super(UseUnusedImport, self).inherited_method2():
+            yield i
+        yield 1
+
     def write(self):
         return super(UseUnusedImport, self).write()
 


### PR DESCRIPTION
Demo case, when _pylint-odoo_ is run on [OCA/website/website_seo_redirection](https://github.com/OCA/website/tree/cc382d3ccef0e550f06feb5ed580a627381e72f7/website_seo_redirection):

```
...
************* Module website_seo_redirection.models.website                                                            
W: 12, 4: Missing `return` (`super` is used) in method enumerate_pages. (missing-return)                               
...
```

However, `enumerate_pages()` is a generator, and [`super()` is called and its values are yielded](https://github.com/OCA/website/blob/cc382d3ccef0e550f06feb5ed580a627381e72f7/website_seo_redirection/models/website.py#L29-L34).

This PR adds a check if the function is a generator when `super()` is called and `return` is missing in the function.