### PR TITLE
[ADD] computed-method-should-not-use-write: A computed method shouldn't use write

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -364,7 +364,9 @@ class NoModuleChecker(BaseChecker):
         }),
     )
 
-    _name_computed_methods = []
+    def __init__(self, *args):
+        self._name_computed_methods = []
+        BaseChecker.__init__(self, *args)
 
     def open(self):
         super(NoModuleChecker, self).open()

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -366,7 +366,7 @@ class NoModuleChecker(BaseChecker):
 
     def __init__(self, *args):
         self._name_computed_methods = []
-        BaseChecker.__init__(self, *args)
+        super(NoModuleChecker, self).__init__(*args)
 
     def open(self):
         super(NoModuleChecker, self).open()

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -482,7 +482,9 @@ class NoModuleChecker(BaseChecker):
                 #               item.write()
                 # Inside the computer method
                 exprs = [item for item in funct.nodes_of_class(astroid.For)
-                         if (item.iter.name == 'self' and
+                         if (isinstance(item.iter,
+                                        astroid.node_classes.Name) and
+                             item.iter.name == 'self' and
                              node.func.expr.name == item.target.name)]
                 for exp in exprs:
                     self.add_message(

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -68,7 +68,7 @@ EXPECTED_ERRORS = {
     'resource-not-exist': 3,
     'website-manifest-key-not-valid-uri': 1,
     'character-not-valid-in-resource-link': 2,
-    'computed-method-should-not-use-write': 3
+    'computed-method-should-not-use-write': 3,
 }
 
 

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -68,6 +68,7 @@ EXPECTED_ERRORS = {
     'resource-not-exist': 3,
     'website-manifest-key-not-valid-uri': 1,
     'character-not-valid-in-resource-link': 2,
+    'computed-method-should-not-use-write': 2
 }
 
 

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -68,7 +68,7 @@ EXPECTED_ERRORS = {
     'resource-not-exist': 3,
     'website-manifest-key-not-valid-uri': 1,
     'character-not-valid-in-resource-link': 2,
-    'computed-method-should-not-use-write': 2
+    'computed-method-should-not-use-write': 3
 }
 
 

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -191,6 +191,9 @@ class TestModel(models.Model):
         for item in items:
             if item:
                 item.write({'name': "Name computed"})
+        for arg in self.my_method1():
+            item.write({'name': "Name computed"})
+
 
     def my_method1(self, variable1):
         #  Shouldn't show error of field-argument-translate

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -176,7 +176,21 @@ class TestModel(models.Model):
     def _compute_name(self):
         self.write({'name': "Name computed"})
         for item in self:
+            if item:
+                item.write({'name': "Name computed"})
+
+    def my_method_compute(self):
+        items = []
+        self.write({'name': "Name computed"})
+        for item in items:
             item.write({'name': "Name computed"})
+
+    def other_method_compute(self):
+        items = []
+        self.write({'name': "Name computed"})
+        for item in items:
+            if item:
+                item.write({'name': "Name computed"})
 
     def my_method1(self, variable1):
         #  Shouldn't show error of field-argument-translate

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -194,7 +194,6 @@ class TestModel(models.Model):
         for arg in self.my_method1():
             item.write({'name': "Name computed"})
 
-
     def my_method1(self, variable1):
         #  Shouldn't show error of field-argument-translate
         self.my_method2(_('hello world'))

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -173,6 +173,11 @@ class TestModel(models.Model):
         help="Many 2 Many"
     )
 
+    def _compute_name(self):
+        self.write({'name': "Name computed"})
+        for item in self:
+            item.write({'name': "Name computed"})
+
     def my_method1(self, variable1):
         #  Shouldn't show error of field-argument-translate
         self.my_method2(_('hello world'))


### PR DESCRIPTION
**WIP**

This new check named `computed-method-should-not-use-write` detects the call to the method `write` inside the computed method

This detects two variants:
- Call directly the method `write`.
```
...
self.write()
...
```
- Transient call to `write` method
```
...
for item in self:
    item.write()
...
```


Fix https://github.com/OCA/pylint-odoo/issues/145