### PR TITLE
[ADD] xml-deprecated-tree-attribute: Implements check for deprecated tree attributes

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -62,6 +62,7 @@ EXPECTED_ERRORS = {
     'attribute-string-redundant': 33,
     'renamed-field-parameter': 2,
     'deprecated-data-xml-node': 5,
+    'xml-deprecated-tree-attribute': 3,
     'resource-not-exist': 3,
     'website-manifest-key-not-valid-uri': 1
 }

--- a/pylint_odoo/test_repo/broken_module/demo/duplicated_id_demo.xml
+++ b/pylint_odoo/test_repo/broken_module/demo/duplicated_id_demo.xml
@@ -6,7 +6,7 @@
             <field name="name">view.model.form</field>
             <field name="model">test.model</field>
             <field name="arch" type="xml">
-                <tree string="Test model">
+                <tree>
                     <field name="name"></field>
                 </tree>
             </field>

--- a/pylint_odoo/test_repo/broken_module/model_view2.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view2.xml
@@ -16,7 +16,7 @@
             <field name="name">view.model.form2</field>
             <field name="model">test.model</field>
             <field name="arch" type="xml">
-                <tree string="Test model 2">
+                <tree>
                     <field name="name"/>
                 </tree>
             </field>

--- a/pylint_odoo/test_repo/broken_module/model_view_odoo.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view_odoo.xml
@@ -6,7 +6,7 @@
             <field name="name">view.model.form</field>
             <field name="model">test.model</field>
             <field name="arch" type="xml">
-                <tree string="Test model">
+                <tree>
                     <field name="name"/>
                 </tree>
             </field>
@@ -17,10 +17,43 @@
             <field name="name">view.model.form</field>
             <field name="model">test.model</field>
             <field name="arch" type="xml">
-                <tree string="Test model">
+                <tree>
                     <field name="name"/>
                 </tree>
 			</field>
+        </record>
+
+        <!--deprecated tree string attribute-->
+        <record id="view_test_model_tree1" model="ir.ui.view">
+            <field name="name">test.model.tree</field>
+            <field name="model">test.model</field>
+            <field name="arch" type="xml">
+                <tree string="Test model">
+                    <field name="name"/>
+                </tree>
+            </field>
+        </record>
+
+        <!--deprecated tree colors attribute-->
+        <record id="view_test_model_tree2" model="ir.ui.view">
+            <field name="name">test.model.tree</field>
+            <field name="model">test.model</field>
+            <field name="arch" type="xml">
+                <tree colors="blue:name='test'">
+                    <field name="name"/>
+                </tree>
+            </field>
+        </record>
+
+        <!--deprecated tree fonts attribute-->
+        <record id="view_test_model_tree3" model="ir.ui.view">
+            <field name="name">test.model.tree</field>
+            <field name="model">test.model</field>
+            <field name="arch" type="xml">
+                <tree fonts="bold:name='test'">
+                    <field name="name"/>
+                </tree>
+            </field>
         </record>
 
         <!--ir.filters without explicit user_id-->

--- a/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
@@ -6,7 +6,7 @@
             <field name="name">view.model.form</field>
             <field name="model">test.model</field>
             <field name="arch" type="xml">
-                <tree string="Test model">
+                <tree>
                     <field name="name"></field>
                 </tree>
             </field>


### PR DESCRIPTION
Implements check for deprecated XML `<tree>` node attributes (`colors`, `fonts` and `string`) as stated in #146.