### PR TITLE
[FIX] manifest-version-format: Adds matching for string end to default manifest version format

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -234,7 +234,7 @@ DFTL_METHOD_REQUIRED_SUPER = [
 DFTL_VALID_ODOO_VERSIONS = [
     '4.2', '5.0', '6.0', '6.1', '7.0', '8.0', '9.0', '10.0'
 ]
-DFTL_MANIFEST_VERSION_FORMAT = r"(%(valid_odoo_versions)s)\.\d+\.\d+\.\d+"
+DFTL_MANIFEST_VERSION_FORMAT = r"(%(valid_odoo_versions)s)\.\d+\.\d+\.\d+$"
 DFTL_CURSOR_EXPR = [
     'self.env.cr', 'self._cr',  # new api
     'self.cr',  # controllers and test

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -35,7 +35,7 @@ EXPECTED_ERRORS = {
     'manifest-deprecated-key': 1,
     'manifest-required-author': 1,
     'manifest-required-key': 1,
-    'manifest-version-format': 2,
+    'manifest-version-format': 3,
     'method-compute': 1,
     'method-inverse': 1,
     'method-required-super': 8,

--- a/pylint_odoo/test_repo/broken_module3/__openerp__.py
+++ b/pylint_odoo/test_repo/broken_module3/__openerp__.py
@@ -4,7 +4,7 @@
     'license': 'AGPL-3',
     'author': ['Other', 'Odoo Community Association (OCA)'],  # expected string
     'website': 'htt://odoo-community.com',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.0.0foo',
     'depends': ['base'],
     'data': [],
     'test': [],


### PR DESCRIPTION
This adds `$` to the end of default manifest version format to disallow versions like `10.0.1.0.0WHATEVER`.

Related: #152