### PR TITLE
[FIX] pylint_odoo: Detect the children inside the odoo xml

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -685,9 +685,12 @@ class ModuleChecker(misc.WrapperModuleChecker):
         self.msg_args = []
         for xml_file in xml_files:
             doc = self.parse_xml(os.path.join(self.module_path, xml_file))
-            odoo_nodes = doc.xpath("/odoo/data") \
+            odoo_nodes = doc.xpath("/odoo") \
                 if not isinstance(doc, basestring) else []
-            if len(odoo_nodes) == 1:
+            children, data_node = ((odoo_nodes[0].getchildren(),
+                                    odoo_nodes[0].findall('data'))
+                                   if odoo_nodes else ([], []))
+            if len(children) == 1 and len(data_node) == 1:
                 lineno = odoo_nodes[0].sourceline
                 self.msg_args.append(("%s:%s" % (xml_file, lineno)))
         if self.msg_args:

--- a/pylint_odoo/test_repo/broken_module/tests/xml_not_important_3.xml
+++ b/pylint_odoo/test_repo/broken_module/tests/xml_not_important_3.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record></record>
+    </data>
+    <record></record>
+</odoo>

--- a/pylint_odoo/test_repo/broken_module/tests/xml_not_important_4.xml
+++ b/pylint_odoo/test_repo/broken_module/tests/xml_not_important_4.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record></record>
+</odoo>


### PR DESCRIPTION
Detect the children inside the odoo xml tag and only active the check `deprecated-data-xml-node` when exist one tag `data` inside de xml

This fix skip the follow case

```xml
<odoo>
    <data noupdate="1">
        <record></record>
    </data>
    <record></record>
</odoo>
```


I run this change over the module of odoo [sales_team](https://github.com/odoo/odoo/tree/saas-17/addons/sales_team)

Without this change the output is the follow
![image](https://user-images.githubusercontent.com/1387970/30218631-801e11f0-9487-11e7-9de3-8eac3eb2833a.png)
The pylint-odoo detect four files



- [addons/sales_team/security/sales_team_security.xml](https://github.com/odoo/odoo/blob/ca496c21989d92b0e1d717faa4e834326188e546/addons/sales_team/security/sales_team_security.xml#L44-L49) **False positive**
- [addons/sales_team/views/crm_team_views.xml](https://github.com/odoo/odoo/blob/ca496c21989d92b0e1d717faa4e834326188e546/addons/sales_team/views/crm_team_views.xml#L212-L215)
- [addons/sales_team/data/sales_team_demo.xml](https://github.com/odoo/odoo/blob/ca496c21989d92b0e1d717faa4e834326188e546/addons/sales_team/data/sales_team_demo.xml#L19-L22)
- [addons/sales_team/data/sales_team_data.xml](https://github.com/odoo/odoo/blob/ca496c21989d92b0e1d717faa4e834326188e546/addons/sales_team/data/sales_team_data.xml#L14-L18) **False positive**

After apply this change over the code the output is the follow
![image](https://user-images.githubusercontent.com/1387970/30218643-8d3025f4-9487-11e7-8fdb-670b1ee8c64e.png)
The pylint-odoo detect two files

- [addons/sales_team/views/crm_team_views.xml](https://github.com/odoo/odoo/blob/ca496c21989d92b0e1d717faa4e834326188e546/addons/sales_team/views/crm_team_views.xml#L212-L215)
- [addons/sales_team/data/sales_team_demo.xml](https://github.com/odoo/odoo/blob/ca496c21989d92b0e1d717faa4e834326188e546/addons/sales_team/data/sales_team_demo.xml#L19-L22)

Fix https://github.com/Vauxoo/pylint-odoo/issues/128