### PR TITLE
[ADD] xml-deprecated-qweb-directive: Implements check for deprecated QWeb directives

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -905,7 +905,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
         self.msg_args = []
         for xml_file in self.filter_files_ext('xml', relpath=False):
             doc = self.parse_xml(xml_file)
-            if isinstance(doc, basestring):
+            if isinstance(doc, string_types):
                 continue
             for node in doc.xpath(xpath):
                 # Find which directive was used exactly.

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -886,8 +886,9 @@ class ModuleChecker(misc.WrapperModuleChecker):
         :return: False if deprecated directives are found, in which case
                  self.msg_args will contain the error messages.
         """
-        if ('10.0' not in self.linter._all_options[
-                'valid_odoo_versions'].config.valid_odoo_versions):
+        valid_versions = set(self.linter._all_options[
+            'valid_odoo_versions'].config.valid_odoo_versions)
+        if not valid_versions & {'10.0', '11.0'}:
             return True
 
         deprecated_directives = {

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -64,6 +64,7 @@ EXPECTED_ERRORS = {
     'renamed-field-parameter': 2,
     'deprecated-data-xml-node': 5,
     'xml-deprecated-tree-attribute': 3,
+    'xml-deprecated-qweb-directive': 2,
     'resource-not-exist': 3,
     'website-manifest-key-not-valid-uri': 1
 }
@@ -136,11 +137,16 @@ class MainTest(unittest.TestCase):
 
     def test_25_checks_without_coverage(self):
         """All odoolint errors vs found"""
+        # Some messages can be excluded as they are only applied on certain
+        # Odoo versions (not necessarily 8.0).
+        excluded_msgs = {
+            'xml-deprecated-qweb-directive',
+        }
         extra_params = ['--valid_odoo_versions=8.0']
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         msgs_found = pylint_res.linter.stats['by_msg'].keys()
-        plugin_msgs = misc.get_plugin_msgs(pylint_res)
-        test_missed_msgs = sorted(list(set(plugin_msgs) - set(msgs_found)))
+        plugin_msgs = set(misc.get_plugin_msgs(pylint_res)) - excluded_msgs
+        test_missed_msgs = sorted(list(plugin_msgs - set(msgs_found)))
         self.assertFalse(
             test_missed_msgs,
             "Checks without test case: {test_missed_msgs}".format(

--- a/pylint_odoo/test_repo/test_module/__openerp__.py
+++ b/pylint_odoo/test_repo/test_module/__openerp__.py
@@ -11,6 +11,7 @@
         'security/ir.model.access.csv',
         'res_users.xml',
         'model_view.xml',
+        'website_templates.xml',
     ],
     'external_dependencies': {
         'bin': [

--- a/pylint_odoo/test_repo/test_module/website_templates.xml
+++ b/pylint_odoo/test_repo/test_module/website_templates.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Deprecated QWeb directive "t-esc-options". -->
+    <template id="test_template_1" name="Test Template 1">
+        <div>
+            <span t-esc="price" t-esc-options='{"widget": "monetary"}'/>
+        </div>
+    </template>
+
+    <!-- Deprecated QWeb directive "t-field-options". -->
+    <template id="test_template_2" name="Test Template 2">
+        <div>
+            <span t-field="line.image" t-field-options='{"widget": "image"}'/>
+        </div>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This adds a check for use of deprecated QWeb directives `t-*-options` (`t-field-options`, `t-esc-options` and `t-raw-options`) which are [to be removed after v10](https://github.com/odoo/odoo/blob/8f99b24f6cb1ea70b371e2944ff36b75a6f9c80e/odoo/addons/base/ir/ir_qweb/ir_qweb.py#L155) and should be replaced with the `t-options` directive.

Currently, you only get a warning in the logs as the templates which use these directives are compiled, but [only in dev mode](https://github.com/odoo/odoo/blob/8f99b24f6cb1ea70b371e2944ff36b75a6f9c80e/odoo/addons/base/ir/ir_qweb/ir_qweb.py#L160-L161) (`--dev` CLI parameter).

I haven't found any usage of `t-raw-options` in Odoo or elsewhere on GitHub, however, it [is theoretically possible](https://github.com/odoo/odoo/blob/8f99b24f6cb1ea70b371e2944ff36b75a6f9c80e/odoo/addons/base/ir/ir_qweb/qweb.py#L1030), so I have included it as well.
