### PR TITLE
[ADD] character-not-valid-in-resource-link: To valid the character '?/#' into the in src/href

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -146,7 +146,7 @@ ODOO_MSGS = {
         settings.DESC_DFLT
     ),
     'W%d44' % settings.BASE_OMODULE_ID: (
-        '%s The character "?/#" is not permitted to adding in src/href',
+        '%s The resource in in src/href contains a not valid chararter',
         'character-not-valid-in-resource-link',
         settings.DESC_DFLT
     ),
@@ -541,7 +541,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
         return True
 
     def _check_character_not_valid_in_resource_link(self):
-        """The character "?/#" is not permitted to adding in src/href"""
+        """The resource in in src/href contains a not valid chararter"""
         self.msg_args = []
         for xml_file in self.filter_files_ext('xml'):
             doc = self.parse_xml(os.path.join(self.module_path, xml_file))
@@ -550,8 +550,9 @@ class ModuleChecker(misc.WrapperModuleChecker):
                          if not isinstance(doc, string_types) else [])
                 for node in nodes:
                     resource = node.get(attr, '')
-                    if (any(key for key in ('?', '#') if key in resource) and
-                            os.path.isabs(resource)):
+                    ext = os.path.splitext(os.path.basename(resource))[1]
+                    if (os.path.isabs(resource) and not
+                            re.search('^[.][a-zA-Z]+$', ext)):
                         self.msg_args.append(("%s:%s" % (xml_file,
                                                          node.sourceline)))
         if self.msg_args:

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -551,7 +551,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
                 for node in nodes:
                     resource = node.get(attr, '')
                     ext = os.path.splitext(os.path.basename(resource))[1]
-                    if (os.path.isabs(resource) and not
+                    if (resource.startswith('/') and not
                             re.search('^[.][a-zA-Z]+$', ext)):
                         self.msg_args.append(("%s:%s" % (xml_file,
                                                          node.sourceline)))

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -144,7 +144,12 @@ ODOO_MSGS = {
         'instead of <odoo><data noupdate="1">',
         'deprecated-data-xml-node',
         settings.DESC_DFLT
-    )
+    ),
+    'W%d44' % settings.BASE_OMODULE_ID: (
+        '%s The character "?/#" is not permitted to adding in src/href',
+        'character-not-valid-in-resource-link',
+        settings.DESC_DFLT
+    ),
 }
 
 
@@ -531,6 +536,24 @@ class ModuleChecker(misc.WrapperModuleChecker):
                     xml_file, self.module):
                 self.msg_args.append(
                     ("%s:%d" % (xml_file_rel, lineno), xml_id))
+        if self.msg_args:
+            return False
+        return True
+
+    def _check_character_not_valid_in_resource_link(self):
+        """The character "?/#" is not permitted to adding in src/href"""
+        self.msg_args = []
+        for xml_file in self.filter_files_ext('xml'):
+            doc = self.parse_xml(os.path.join(self.module_path, xml_file))
+            for name, attr in (('link', 'href'), ('script', 'src')):
+                nodes = (doc.xpath('.//%s[@%s]' % (name, attr))
+                         if not isinstance(doc, string_types) else [])
+                for node in nodes:
+                    resource = node.get(attr, '')
+                    if (any(key for key in ('?', '#') if key in resource) and
+                            os.path.isabs(resource)):
+                        self.msg_args.append(("%s:%s" % (xml_file,
+                                                         node.sourceline)))
         if self.msg_args:
             return False
         return True

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -67,7 +67,7 @@ EXPECTED_ERRORS = {
     'xml-deprecated-qweb-directive': 2,
     'resource-not-exist': 3,
     'website-manifest-key-not-valid-uri': 1,
-    'character-not-valid-in-resource-link': 2
+    'character-not-valid-in-resource-link': 2,
 }
 
 

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -66,7 +66,8 @@ EXPECTED_ERRORS = {
     'xml-deprecated-tree-attribute': 3,
     'xml-deprecated-qweb-directive': 2,
     'resource-not-exist': 3,
-    'website-manifest-key-not-valid-uri': 1
+    'website-manifest-key-not-valid-uri': 1,
+    'character-not-valid-in-resource-link': 2
 }
 
 

--- a/pylint_odoo/test_repo/test_module/website_templates.xml
+++ b/pylint_odoo/test_repo/test_module/website_templates.xml
@@ -15,4 +15,18 @@
         </div>
     </template>
 
+    <template id="assets_backend" name="test_module_widget" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <!-- wrong but is working in odoo web debug mode -->
+            <link rel="stylesheet" href="/test_module_widget/static/widget.css?v=1"/>
+
+            <script type="text/javascript" src="/test_module_affiliation_widget/static/widget.js?v=1"/>
+
+            <!-- correct but is working working odoo web debug mode also -->
+            <link rel="stylesheet" href="/test_module_widget/static/widget.css"/>
+
+            <script type="text/javascript" src="/test_module_affiliation_widget/static/widget.js"/>
+        </xpath>
+    </template>
+
 </odoo>

--- a/pylint_odoo/test_repo/test_module/website_templates.xml
+++ b/pylint_odoo/test_repo/test_module/website_templates.xml
@@ -17,15 +17,18 @@
 
     <template id="assets_backend" name="test_module_widget" inherit_id="web.assets_backend">
         <xpath expr="." position="inside">
-            <!-- wrong but is working in odoo web debug mode -->
+            <!-- Wrong but is working in odoo web debug mode -->
             <link rel="stylesheet" href="/test_module_widget/static/widget.css?v=1"/>
 
             <script type="text/javascript" src="/test_module_affiliation_widget/static/widget.js?v=1"/>
 
-            <!-- correct but is working working odoo web debug mode also -->
+            <!-- Correct but is working working odoo web debug mode also -->
             <link rel="stylesheet" href="/test_module_widget/static/widget.css"/>
 
             <script type="text/javascript" src="/test_module_affiliation_widget/static/widget.js"/>
+
+            <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"/>
+            <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js?_ca=235"/>
         </xpath>
     </template>
 


### PR DESCRIPTION
This pull request check if the `<script src>` or `<link href>` contains the character `?` or `#`  and if this a valid absolute path

Fix https://github.com/OCA/pylint-odoo/issues/160#issuecomment-336995763