### PR TITLE
[FIX] pylint_odoo: Check if the package start with dot to skip

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -369,6 +369,8 @@ class ModuleChecker(misc.WrapperModuleChecker):
 
         ext_deps = self.manifest_dict.get('external_dependencies') or {}
         py_ext_deps = ext_deps.get('python') or []
+        if isinstance(node, astroid.ImportFrom) and (node.level or 0) >= 1:
+            return
         if module_name not in py_ext_deps and \
                 module_name.split('.')[0] not in py_ext_deps:
             self.add_message('missing-manifest-dependency', node=node,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -41,7 +41,7 @@ EXPECTED_ERRORS = {
     'method-inverse': 1,
     'method-required-super': 8,
     'method-search': 1,
-    'missing-import-error': 3,
+    'missing-import-error': 4,
     'missing-manifest-dependency': 2,
     'missing-newline-extrafiles': 4,
     'missing-readme': 1,

--- a/pylint_odoo/test_repo/broken_module/models/model_inhe1.py
+++ b/pylint_odoo/test_repo/broken_module/models/model_inhe1.py
@@ -1,10 +1,14 @@
 # coding: utf-8
 
 from openerp import models
+from .no_exists import package
 
 
 class TestModel(models.Model):
     _inherit = 'res.company'
+
+    def method(self):
+        return package
 
 
 class TestModel2(models.Model):


### PR DESCRIPTION
Check if the package start with dot to skip because this package is absolute import

This change now detect when the import start with dot for example

```python
from .no_exists import package
```
If the import start with dot that import is not detect as external dependency 

Related with https://github.com/Vauxoo/pylint-odoo/pull/134

Fix https://github.com/OCA/pylint-odoo/issues/170
