### PR TITLE
[FIX] pylint_odoo: The check duplicate-xml-fields skip if the field is inside the search tag

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -571,23 +571,13 @@ class ModuleChecker(misc.WrapperModuleChecker):
             name = field.attrib.get('name')
             context = field.attrib.get('context')
             filter_domain = field.attrib.get('filter_domain')
-            sourceline = field.sourceline
             if not name:
                 continue
-            for in_field in fields:
-                if ((not in_field.attrib.get('name') or
-                     sourceline == in_field.sourceline) or
-                    (not
-                     (name == in_field.attrib.get('name') and
-                      context == in_field.attrib.get('context') and
-                      filter_domain == in_field.attrib.get('filter_domain')))):
-                    continue
-                all_fields.setdefault(
-                    (field.attrib.get('name'),
-                     field.getparent()), []).append(field)
+            all_fields.setdefault(
+                (name, context, filter_domain, field.getparent()), []).append(field)
         # Remove all keys which not duplicated by excluding them from the
-        return dict(((field_xml_name, parent_node), nodes) for
-                    (field_xml_name, parent_node), nodes in
+        return dict(((name, context, filter_domain, parent_node), nodes) for
+                    (name, context, filter_domain, parent_node), nodes in
                     all_fields.items() if len(nodes) >= 2)
 
     def _check_duplicate_xml_fields(self):

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -568,14 +568,25 @@ class ModuleChecker(misc.WrapperModuleChecker):
         """
         all_fields = {}
         for field in fields:
-            field_xml = field.attrib.get('name')
-            if (not field_xml or (field.getparent() and
-                                  field.getparent().tag == 'search')):
+            name = field.attrib.get('name')
+            context = field.attrib.get('context')
+            filter_domain = field.attrib.get('filter_domain')
+            sourceline = field.sourceline
+            if not name:
                 continue
-            all_fields.setdefault(
-                (field_xml, field.getparent()), []).append(field)
+            for in_field in fields:
+                if ((not in_field.attrib.get('name') or
+                     sourceline == in_field.sourceline)
+                    or
+                    (not
+                     (name == in_field.attrib.get('name') and
+                      context == in_field.attrib.get('context') and
+                      filter_domain == in_field.attrib.get('filter_domain')))):
+                    continue
+                all_fields.setdefault(
+                    (field.attrib.get('name'),
+                     field.getparent()), []).append(field)
         # Remove all keys which not duplicated by excluding them from the
-        # returning dict
         return dict(((field_xml_name, parent_node), nodes) for
                     (field_xml_name, parent_node), nodes in
                     all_fields.items() if len(nodes) >= 2)

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -569,7 +569,8 @@ class ModuleChecker(misc.WrapperModuleChecker):
         all_fields = {}
         for field in fields:
             field_xml = field.attrib.get('name')
-            if not field_xml:
+            if (not field_xml or (field.getparent()
+                                  and field.getparent().tag == 'search')):
                 continue
             all_fields.setdefault(
                 (field_xml, field.getparent()), []).append(field)

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -576,8 +576,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
                 continue
             for in_field in fields:
                 if ((not in_field.attrib.get('name') or
-                     sourceline == in_field.sourceline)
-                    or
+                     sourceline == in_field.sourceline) or
                     (not
                      (name == in_field.attrib.get('name') and
                       context == in_field.attrib.get('context') and

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -574,7 +574,8 @@ class ModuleChecker(misc.WrapperModuleChecker):
             if not name:
                 continue
             all_fields.setdefault(
-                (name, context, filter_domain, field.getparent()), []).append(field)
+                (name, context, filter_domain, field.getparent()),
+                []).append(field)
         # Remove all keys which not duplicated by excluding them from the
         return dict(((name, context, filter_domain, parent_node), nodes) for
                     (name, context, filter_domain, parent_node), nodes in

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -568,14 +568,13 @@ class ModuleChecker(misc.WrapperModuleChecker):
         """
         all_fields = {}
         for field in fields:
-            name = field.attrib.get('name')
-            context = field.attrib.get('context')
-            filter_domain = field.attrib.get('filter_domain')
-            if not name:
+            field_xml = field.attrib.get('name')
+            if not field_xml:
                 continue
             all_fields.setdefault(
-                (name, context, filter_domain, field.getparent()),
-                []).append(field)
+                (field_xml, field.attrib.get('context'),
+                 field.attrib.get('filter_domain'),
+                 field.getparent()), []).append(field)
         # Remove all keys which not duplicated by excluding them from the
         return dict(((name, context, filter_domain, parent_node), nodes) for
                     (name, context, filter_domain, parent_node), nodes in

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -569,8 +569,8 @@ class ModuleChecker(misc.WrapperModuleChecker):
         all_fields = {}
         for field in fields:
             field_xml = field.attrib.get('name')
-            if (not field_xml or (field.getparent()
-                                  and field.getparent().tag == 'search')):
+            if (not field_xml or (field.getparent() and
+                                  field.getparent().tag == 'search')):
                 continue
             all_fields.setdefault(
                 (field_xml, field.getparent()), []).append(field)

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -25,7 +25,7 @@ EXPECTED_ERRORS = {
     'dangerous-view-replace-wo-priority': 5,
     'deprecated-openerp-xml-node': 5,
     'duplicate-id-csv': 2,
-    'duplicate-xml-fields': 8,
+    'duplicate-xml-fields': 9,
     'duplicate-xml-record-id': 2,
     'file-not-used': 6,
     'incoherent-interpreter-exec-perm': 3,

--- a/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
@@ -37,8 +37,9 @@
             <field name="model">ir.config_parameter</field>
             <field name="arch" type="xml">
                 <search string="System Properties">
-                    <field name="key_config" context="{'one': 'data'}"/>
-                    <field name="key_config" context="{'two': 'data'}"/>
+                    <field name="key_config" context="{'one': 'data'}" filter_domain="[('field', '=' 'one')]"/>
+                    <field name="key_config" context="{'two': 'data'}" filter_domain="[('field', '=' 'two')]"/>
+                    <field name="key_config" context="{'two': 'data'}" filter_domain="[('field', '=' 'two')]"/>
                 </search>
             </field>
         </record>

--- a/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
@@ -32,6 +32,17 @@
             </field>
         </record>
 
+        <!-- duplicate record field "name" inside the search -->
+        <record model="ir.ui.view" id="view_ir_config_search">
+            <field name="model">ir.config_parameter</field>
+            <field name="arch" type="xml">
+                <search string="System Properties">
+                    <field name="key_config" context="{'one': 'data'}"/>
+                    <field name="key_config" context="{'two': 'data'}"/>
+                </search>
+            </field>
+        </record>
+
          <!-- inherit view without duplicated is not checked -->
         <record id="view_model_form4" model="ir.ui.view">
             <field name="name">view.model.form</field>


### PR DESCRIPTION
The check `duplicate-xml-fields` skip the comprobation if the field is inside the `search` tab

For example 

```xml
<record model="ir.ui.view" id="view_ir_config_search">
    <field name="model">ir.config_parameter</field>
    <field name="arch" type="xml">
        <search string="System Properties">
            <field name="key_config" context="{'one': 'data'}"/>
            <field name="key_config" context="{'two': 'data'}"/>
        </search>
    </field>
</record>
```

Fix https://github.com/OCA/pylint-odoo/issues/169
