### PR TITLE
[FIX] pylint_odoo: Change the number of the appearances of the check unnecessary-utf8-coding-comment

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -47,7 +47,7 @@ EXPECTED_ERRORS = {
     'missing-readme': 1,
     'missing-return': 1,
     'no-utf8-coding-comment': 3,
-    'unnecessary-utf8-coding-comment': 18,
+    'unnecessary-utf8-coding-comment': 19,
     'odoo-addons-relative-import': 4,
     'old-api7-method-defined': 2,
     'openerp-exception-warning': 3,


### PR DESCRIPTION
Change the number of the appearances of the check `unnecessary-utf8-coding-comment`

Because this pull request https://github.com/OCA/pylint-odoo/pull/171 adding another file with `# coding: utf-8`

https://github.com/OCA/pylint-odoo/blob/2f26b156629ac27f0d0d40db46438fa87ef29537/pylint_odoo/test_repo/broken_module/models/model_inhe1.py#L1-L3