### PR TITLE
[FIX] pylint_odoo: Use check-name instead of check-code for add_message method

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -173,7 +173,7 @@ class PylintOdooChecker(BaseChecker):
                         node_lineno_original = node.lineno
                         msg_args_extra = self.set_extra_file(node, msg_args,
                                                              msg_code)
-                        self.add_message(msg_code, line=node.lineno, node=node,
+                        self.add_message(name_key, line=node.lineno, node=node,
                                          args=msg_args_extra)
                         node.file = node_file_original
                         node.lineno = node_lineno_original


### PR DESCRIPTION
When a check is found the method `add_message` is called with the number of the check `W7904` instead of the name of the check `deprecated-openerp-xml-node`

This change is necessary to used the new configuration `odoo_check_versions` like this:

```python
    odoo_check_versions = {                                                     
        'useless-attribute-non-translatable': {                                 
            'min_odoo_version': '8.0',                                          
        },                                                                                                                                                                                             
   } 
```

Without this change the `odoo_check_versions` should be like this:

```python
    odoo_check_versions = {                                                     
        'W7904': {                                 
            'min_odoo_version': '8.0',                                          
        },                                                                                                                                                                                             
   } 
```

This change is only to keep more readable the `odoo_check_versions`