### PR TITLE
[REF] The method message_post need the subject and body be translatable

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -55,7 +55,7 @@ EXPECTED_ERRORS = {
     'rst-syntax-error': 2,
     'sql-injection': 15,
     'translation-field': 2,
-    'translation-required': 4,
+    'translation-required': 14,
     'use-vim-comment': 1,
     'wrong-tabs-instead-of-spaces': 2,
     'eval-referenced': 5,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -21,6 +21,8 @@ def function_no_method():
 class TestModel(models.Model):
     _name = 'test.model'
 
+    _inherit = ['mail.thread']
+
     _columns = {}  # deprecated columns
     _defaults = {}  # deprecated defaults
     length = fields.Integer()  # Deprecated length by js errors
@@ -176,6 +178,29 @@ class TestModel(models.Model):
     def my_method1(self, variable1):
         #  Shouldn't show error of field-argument-translate
         self.my_method2(_('hello world'))
+
+        # Message post without translation function
+        self.message_post(subject='Subject not translatable',
+                          body='Body not translatable %s' % variable1)
+        self.message_post(subject='Subject not translatable %(variable)s' %
+                          {'variable': variable1},
+                          body='Body not translatable {}'.format(variable1),
+                          message_type='notification')
+        self.message_post('Body not translatable',
+                          'Subject not translatable {a}'.format(a=variable1))
+        self.message_post('Body not translatable %s' % variable1,
+                          'Subject not translatable %(variable)s' %
+                          {'variable': variable1})
+        self.message_post('Body not translatable',
+                          subject='Subject not translatable')
+
+        # Message post with translation function
+        self.message_post(subject=_('Subject not translatable'),
+                          body=_('Body not translatable'))
+        self.message_post(_('Body not translatable'),
+                          _('Subject not translatable'))
+        self.message_post(_('Body not translatable'),
+                          subject=_('Subject not translatable'))
 
     def my_method2(self, variable2):
         return variable2


### PR DESCRIPTION
The check `translation-required` now detects the parameter `subject` and `body` into the method `message_post`, those parameter should be translatable

This change detect when the parameter `subject` and `body` not is translatable, one example like the follow
```python
    self.message_post(subject='Subject not translatable',
        body='Body not translatable')
```

This change detects many way to not translatable string

```python
'Subject not translatable'
'Body not translatable %s' % variable
'Subject not translatable %(value)s' % {'value': variable}
'Subject not translatable {}'.format(variable)

```

Fix https://github.com/OCA/pylint-odoo/issues/176 