### PR TITLE
[REF] pylint_odoo: Modificar all check if that need specific Odoo version

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -246,6 +246,9 @@ class ModuleChecker(misc.WrapperModuleChecker):
     odoo_check_versions = {
         'xml-deprecated-qweb-directive': {
             'min_odoo_version': '10.0',
+        },
+        'deprecated-openerp-xml-node': {
+            'min_odoo_version': '9.0'
         }
     }
 

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -249,6 +249,9 @@ class ModuleChecker(misc.WrapperModuleChecker):
         },
         'deprecated-openerp-xml-node': {
             'min_odoo_version': '9.0'
+        },
+        'deprecated-data-xml-node': {
+            'min_odoo_version': '9.0'
         }
     }
 

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -243,6 +243,12 @@ class ModuleChecker(misc.WrapperModuleChecker):
 
     class_inherit_names = []
 
+    odoo_check_versions = {
+        'xml-deprecated-qweb-directive': {
+            'min_odoo_version': '10.0',
+        }
+    }
+
     @utils.check_messages('consider-merging-classes-inherited')
     def visit_assign(self, node):
         if not self.odoo_node:
@@ -909,11 +915,6 @@ class ModuleChecker(misc.WrapperModuleChecker):
         :return: False if deprecated directives are found, in which case
                  self.msg_args will contain the error messages.
         """
-        valid_versions = set(self.linter._all_options[
-            'valid_odoo_versions'].config.valid_odoo_versions)
-        if not valid_versions & {'10.0', '11.0'}:
-            return True
-
         deprecated_directives = {
             't-esc-options',
             't-field-options',

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -354,6 +354,12 @@ class NoModuleChecker(misc.PylintOdooChecker):
         }),
     )
 
+    odoo_check_versions = {
+        'openerp-exception-warning': {
+            'min_odoo_version': '9.0'
+        }
+    }
+
     def open(self):
         super(NoModuleChecker, self).open()
         self.config.deprecated_field_parameters = \

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -144,7 +144,7 @@ class MainTest(unittest.TestCase):
         excluded_msgs = {
             'xml-attribute-translatable',
         }
-        extra_params = []
+        extra_params = ['--valid_odoo_versions=8.0']
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         msgs_found = pylint_res.linter.stats['by_msg'].keys()
         plugin_msgs = set(misc.get_plugin_msgs(pylint_res)) - excluded_msgs

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -141,7 +141,7 @@ class MainTest(unittest.TestCase):
         """All odoolint errors vs found"""
         # Some messages can be excluded as they are only applied on certain
         # Odoo versions (not necessarily 8.0).
-        extra_params = ['--valid_odoo_versions=8.0']
+        extra_params = []
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         msgs_found = pylint_res.linter.stats['by_msg'].keys()
         plugin_msgs = set(misc.get_plugin_msgs(pylint_res))

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -141,10 +141,13 @@ class MainTest(unittest.TestCase):
         """All odoolint errors vs found"""
         # Some messages can be excluded as they are only applied on certain
         # Odoo versions (not necessarily 8.0).
+        excluded_msgs = {
+            'xml-attribute-translatable',
+        }
         extra_params = []
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         msgs_found = pylint_res.linter.stats['by_msg'].keys()
-        plugin_msgs = set(misc.get_plugin_msgs(pylint_res))
+        plugin_msgs = set(misc.get_plugin_msgs(pylint_res)) - excluded_msgs
         test_missed_msgs = sorted(list(plugin_msgs - set(msgs_found)))
         self.assertFalse(
             test_missed_msgs,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -141,13 +141,10 @@ class MainTest(unittest.TestCase):
         """All odoolint errors vs found"""
         # Some messages can be excluded as they are only applied on certain
         # Odoo versions (not necessarily 8.0).
-        excluded_msgs = {
-            'xml-deprecated-qweb-directive',
-        }
         extra_params = ['--valid_odoo_versions=8.0']
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         msgs_found = pylint_res.linter.stats['by_msg'].keys()
-        plugin_msgs = set(misc.get_plugin_msgs(pylint_res)) - excluded_msgs
+        plugin_msgs = set(misc.get_plugin_msgs(pylint_res))
         test_missed_msgs = sorted(list(plugin_msgs - set(msgs_found)))
         self.assertFalse(
             test_missed_msgs,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -143,6 +143,8 @@ class MainTest(unittest.TestCase):
         # Odoo versions (not necessarily 8.0).
         excluded_msgs = {
             'xml-attribute-translatable',
+            'deprecated-data-xml-node',
+            'openerp-exception-warning',
         }
         extra_params = ['--valid_odoo_versions=8.0']
         pylint_res = self.run_pylint(self.paths_modules, extra_params)


### PR DESCRIPTION
Modify all check that depends on the Odoo version to use the new way to skip the check if that check fails with the Odoo version

The following check needs the Odoo version

- [x] xml-deprecated-qweb-directive
- [x] deprecated-openerp-xml-node
- [x] deprecated-data-xml-node




Fix https://github.com/OCA/pylint-odoo/issues/180