### PR TITLE
Allow short ternary expressions

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -190,7 +190,7 @@
     "max-params": "off",
     "max-statements": "off",
     "max-statements-per-line": "error",
-    "multiline-ternary": "error",
+    "multiline-ternary": "off",
     "new-cap": "off",
     "new-parens": "error",
     "newline-after-var": "off",


### PR DESCRIPTION
Right now this fails:

```js
var what = really ? "yes" : "no";
```

Ref: https://eslint.org/docs/rules/multiline-ternary

@Tecnativa