### PR TITLE
[FIX] translation-required: Fix some false positives

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -55,7 +55,7 @@ EXPECTED_ERRORS = {
     'rst-syntax-error': 2,
     'sql-injection': 15,
     'translation-field': 2,
-    'translation-required': 14,
+    'translation-required': 15,
     'use-vim-comment': 1,
     'wrong-tabs-instead-of-spaces': 2,
     'eval-referenced': 5,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -193,14 +193,39 @@ class TestModel(models.Model):
                           {'variable': variable1})
         self.message_post('Body not translatable',
                           subject='Subject not translatable')
+        self.message_post(body='<h1>%s</h1><p>%s</p>' % (
+            _('Paragraph translatable'), 'Paragraph not translatable'))
 
         # Message post with translation function
-        self.message_post(subject=_('Subject not translatable'),
-                          body=_('Body not translatable'))
-        self.message_post(_('Body not translatable'),
-                          _('Subject not translatable'))
-        self.message_post(_('Body not translatable'),
-                          subject=_('Subject not translatable'))
+        self.message_post(subject=_('Subject translatable'),
+                          body=_('Body translatable'))
+        self.message_post(_('Body translatable'),
+                          _('Subject translatable'))
+        self.message_post(_('Body translatable'),
+                          subject=_('Subject translatable'))
+        self.message_post(_('A CDR has been recovered for %s') % (variable1,))
+        self.message_post(_('A CDR has been recovered for %s') % variable1)
+        self.message_post(_('Var {a}').format(a=variable1))
+        self.message_post(_('Var %(variable)s') % {'variable': variable1})
+        self.message_post(subject=_('Subject translatable'),
+                          body=_('Body translatable %s') % variable1)
+        self.message_post(subject=_('Subject translatable %(variable)s') %
+                          {'variable': variable1},
+                          message_type='notification')
+        self.message_post(_('Body translatable'),
+                          _('Subject translatable {a}').format(a=variable1))
+        self.message_post(_('Body translatable %s') % variable1,
+                          _('Subject translatable %(variable)s') %
+                          {'variable': variable1})
+        self.message_post('<p>%s</p>' % _('Body translatable'))
+        self.message_post(body='<p>%s</p>' % _('Body translatable'))
+
+        # There is no way to know if the variable is translated, then ignoring
+        self.message_post(variable1)
+        self.message_post(body=variable1 + variable1)
+        self.message_post(body=(variable1 + variable1))
+        self.message_post(body=variable1 % variable1)
+        self.message_post(body=(variable1 % variable1))
 
     def my_method2(self, variable2):
         return variable2


### PR DESCRIPTION
This change causes the lint translation-required to take into account
certain cases which were triggering false positives, like the following:

`self.message_post(body=_('error: %s') % error_code)`

i.e. tose messages involving variables in the message string.

In addition, this adds some cases to the tests, to ensure they work as
expected.

Closes #187 