### PR TITLE
[REF] .travis.yml: Allow both W503 and W504 formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
     - pip install restructuredtext_lint pygments
 
 script:
-    - flake8 --ignore=F601 --exclude=__init__.py .
+    - flake8 --ignore=F601,W503,W504 --exclude=__init__.py .
     - restructuredtext-lint ${TRAVIS_BUILD_DIR}/README.rst
     - tox -e $TOXENV,profile-stats
 


### PR DESCRIPTION
This change allows both formatting styles when a line break is around a
binary operator, to be before or after the operator. This is due to a
change in PEP-8 recomendations.

For more info, see the following MQT issue:
https://github.com/OCA/maintainer-quality-tools/issues/545