### PR TITLE
Add _register_hook in "no missing return" methods

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -249,7 +249,7 @@ DFTL_ODOO_EXCEPTIONS = [
     'ValidationError', 'Warning',
 ]
 DFTL_NO_MISSING_RETURN = [
-    '__init__', 'setUp', 'setUpClass', 'tearDown',
+    '__init__', 'setUp', 'setUpClass', 'tearDown', '_register_hook',
 ]
 FIELDS_METHOD = {
     'Many2many': 4,


### PR DESCRIPTION
The return of the _register_hook method is never used, this is the
calling code in the loading phase:

```
    # STEP 8: call _register_hook on every model
    env = api.Environment(cr, SUPERUSER_ID, {})
    for model in env.values():
        model._register_hook()
```

It is then no customary and useless to return something.