### PR TITLE
[FIX] Include six in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ restructuredtext_lint==1.1
 isort==4.3.4
 whichcraft
 rfc3986
+six


### PR DESCRIPTION
It happens that some files use `six` library, but that library is not in `requirements.txt` file. Thus, this PR fixes that.