### PR TITLE
Jslint jsdoc relax

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -14,7 +14,7 @@
   "rules": {
     "no-alert": "error",
     "no-array-constructor": "error",
-    "no-bitwise": "error",
+    "no-bitwise": "off",
     "no-caller": "error",
     "no-case-declarations": "error",
     "no-catch-shadow": "error",
@@ -51,7 +51,9 @@
     "no-fallthrough": "error",
     "no-floating-decimal": "error",
     "no-func-assign": "error",
-    "no-implicit-coercion": "error",
+    "no-implicit-coercion": ["error", {
+      "allow": ["~"]
+    }],
     "no-implicit-globals": "error",
     "no-implied-eval": "error",
     "no-inline-comments": "error",
@@ -144,12 +146,19 @@
     "arrow-spacing": "off",
     "accessor-pairs": "error",
     "block-scoped-var": "off",
-    "block-spacing": "off",
+    "block-spacing": ["error", "always"],
     "brace-style": "error",
     "callback-return": "error",
     "camelcase": "off",
-    "comma-dangle": "off",
-    "comma-spacing": "off",
+    "capitalized-comments": ["error", "always", {
+      "ignoreConsecutiveComments": true,
+      "ignoreInlineComments": true
+    }],
+    "comma-dangle": ["error", "always-multiline"],
+    "comma-spacing": ["error", {
+      "before": false,
+      "after": true
+    }],
     "comma-style": "error",
     "complexity": [
       "error",
@@ -174,18 +183,22 @@
     "id-blacklist": "error",
     "id-length": "off",
     "id-match": "error",
-    "indent": "off",
+    "indent": "error",
     "init-declarations": "error",
     "jsx-quotes": "error",
     "key-spacing": "off",
-    "keyword-spacing": "off",
+    "keyword-spacing": "error",
     "linebreak-style": [
       "error",
       "unix"
     ],
-    "lines-around-comment": "off",
+    "lines-around-comment": "error",
     "max-depth": "error",
-    "max-len": "off",
+    "max-len": ["error", {
+      "code": 80,
+      "ignorePattern": "odoo\\.define\\(",
+      "tabWidth": 4
+    }],
     "max-lines": "off",
     "max-nested-callbacks": "error",
     "max-params": "off",
@@ -197,9 +210,11 @@
     "newline-after-var": "off",
     "newline-before-return": "off",
     "newline-per-chained-call": "off",
-    "object-curly-newline": "off",
-    "object-curly-spacing": "off",
-    "object-property-newline": "off",
+    "object-curly-newline": ["error", { "consistent": true }],
+    "object-curly-spacing": ["error", "never"],
+    "object-property-newline": ["error", {
+      "allowAllPropertiesOnSameLine": true
+    }],
     "object-shorthand": "off",
     "one-var": "off",
     "one-var-declaration-per-line": "off",
@@ -215,23 +230,31 @@
     "quote-props": "off",
     "quotes": "off",
     "radix": "error",
-    "require-jsdoc": "off",
+    "require-jsdoc": ["warn", {
+      "require": {
+        "FunctionDeclaration": true,
+        "MethodDefinition": true,
+        "ClassDeclaration": true,
+        "ArrowFunctionExpression": true,
+        "FunctionExpression": true
+      }
+    }],
     "require-yield": "error",
     "rest-spread-spacing": "off",
     "semi": [
       "error",
       "always"
     ],
-    "semi-spacing": "off",
-    "sort-imports": "off",
+    "semi-spacing": "error",
+    "sort-imports": "error",
     "sort-vars": "off",
-    "space-before-blocks": "off",
-    "space-before-function-paren": "off",
+    "space-before-blocks": "error",
+    "space-before-function-paren": "error",
     "space-in-parens": "off",
     "space-infix-ops": "off",
     "space-unary-ops": "off",
-    "spaced-comment": "off",
-    "strict": "off",
+    "spaced-comment": ["error", "always"],
+    "strict": ["error", "function"],
     "template-curly-spacing": "off",
     "unicode-bom": "error",
     "use-isnan": "error",
@@ -258,7 +281,10 @@
         "str": "String",
         "string": "String"
       },
-      "requireReturn": false
+      "requireParamDescription": false,
+      "requireReturn": false,
+      "requireReturnDescription": false,
+      "requireReturnType": false
     }],
     "valid-typeof": "error",
     "vars-on-top": "off",

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -30,7 +30,7 @@ EXPECTED_ERRORS = {
     'file-not-used': 6,
     'incoherent-interpreter-exec-perm': 3,
     'invalid-commit': 4,
-    'javascript-lint': 22,
+    'javascript-lint': 25,
     'license-allowed': 1,
     'manifest-author-string': 1,
     'manifest-deprecated-key': 1,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -30,7 +30,7 @@ EXPECTED_ERRORS = {
     'file-not-used': 6,
     'incoherent-interpreter-exec-perm': 3,
     'invalid-commit': 4,
-    'javascript-lint': 13,
+    'javascript-lint': 22,
     'license-allowed': 1,
     'manifest-author-string': 1,
     'manifest-deprecated-key': 1,


### PR DESCRIPTION

## Relax some rules for jsdoc comments

This relaxation comes from the fact that sometimes you're extending another object, and thus you don't need to reexplain everything if it is explained in the parent class.

A common coding pattern is:

```js
return this._super.apply(this, arguments);
```

In such cases, it should be enough to declare the return type, since further descriptions should be found in the upstream class.

Another common pattern is reusing upstream parameters, or using parameters with names that are specific enough so as to not require a description, so the requirement of param description is relaxed here too.

## Some more coding styling

- Disable inline block spacing.
- Require multiline dangling commas.
- Enforce PEP8-like line limits.
- Require spaces before comments.
- Requre `"use strict"`.

---
@Tecnativa