### PR TITLE
Allow usage of `undefined`

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -118,7 +118,7 @@
     "no-throw-literal": "error",
     "no-undef": "error",
     "no-undef-init": "error",
-    "no-undefined": "error",
+    "no-undefined": "off",
     "no-unexpected-multiline": "error",
     "no-underscore-dangle": "off",
     "no-unmodified-loop-condition": "error",


### PR DESCRIPTION
ES3 doesn't matter today, so this rule makes no sense.

@Tecnativa