### PR TITLE
[REF] tox: Upgrade new pylint for py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,37 +6,22 @@ cache:
   directories:
     - $HOME/.cache/pip
 
-addons:
-  apt:
-    packages:
-      - python-lxml  # because pip installation is slow
-
 matrix:
   include:
     - python: 2.7
       env:
-        TOXENV=py27-pylint14
-    - python: 2.7
-      env:
-        TOXENV=py27-pylint20
+        TOXENV=py27-pylint19
     - python: 3.5
       env:
-        TOXENV=py35-pylint14
-    - python: 3.5
-      env:
-        TOXENV=py35-pylint20
+        TOXENV=py35-pylint2
     - python: 3.7-dev
       env:
-        TOXENV=py37-pylint14
-    - python: 3.7-dev
-      env:
-        TOXENV=py37-pylint20
+        TOXENV=py37-pylint2
 
 
 install:
     - nvm install 6  # Update nodejs version to 6.latest, required by eslint
     # Remove packages installed from addons-apt-packages of travis file
-    - sed -i '/lxml/d'  ${TRAVIS_BUILD_DIR}/requirements.txt
     - sed -i '/node/d' ${TRAVIS_BUILD_DIR}/install.sh
     - sed -i '/pip install ./d' ${TRAVIS_BUILD_DIR}/install.sh
 
@@ -69,5 +54,5 @@ deploy:
     secure: hKfey6oW+K7HWxE6NJP4O9NtLnnrlofvyLAdoTk6TTA5ucqVizud7vAZN2eCu4Ftw+coTvmJLnZiy9qAREPhe3yeVyfcAOJZr4qQpH8Nzm0VKzKvOpq0L0PTFaNk1Btmmw7lbicGZsLm2qLj0dgg8pDBQ/q6U+A54gfAy3ddIAcdOP1tfdVIC1TPuSXxa8IBEec4BLE4Ao/gKoUBV9MSWyd3TgUbEycNAHHU27muhGxzEyOMW4GBgklyAjwtCzcMIPP8YW8uethCw+9nvU6q1petJYviLwM+txYrHHrgENS2yec8oFbqfXzYXprrx05BHvSdBZT5Rq2tGo02FG17FZ/HNx7g0lS7pRcyfx+8Vapf88pJdaW9rQmP90PEV5mO7EpOJ30s+xp02OIeUSkNIhIXCf9EGibW2gQynljqyuHdl1pBabBSFxA/9JICEyGEYkIRnOaKKzqBHjcpvh0AgpD/JpX5YkIc9bGjYRMiKh7bVM0JXHk1RUeC70jqAGRCObFGBF94O02POoOsRNL3+y7B+tEfbfpaSQQzqGtcfNpR/x6I5MzgNTDMGnzeUipiZM0dYaqcHdY8eAwKRMXIBVmB9JxRP+qjKtg+gSHSB4Mcmgm7hwyUWAvmxt3BnlHfF+ayyKzd0idnjGR0Gd2korndxGf0ZBbSqjkgCtPpdow=
   on:
     tags: true
-    condition: $TOXENV == py27-pylint14
+    condition: $TOXENV == py37-pylint2
     repo: OCA/pylint-odoo

--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -251,7 +251,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
                 'consider-merging-classes-inherited', node.lineno):
             return
         node_left = node.targets[0]
-        if not isinstance(node_left, astroid.node_classes.AssName) or \
+        if not isinstance(node_left, astroid.node_classes.AssignName) or \
                 node_left.name not in ('_inherit', '_name') or \
                 not isinstance(node.value, astroid.node_classes.Const) or \
                 not isinstance(node.parent, astroid.ClassDef):

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -389,7 +389,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
                      not (isinstance(node.right, astroid.Attribute) and
                           node.right.attrname.startswith('_')))
 
-        is_format = (isinstance(node, astroid.CallFunc) and
+        is_format = (isinstance(node, astroid.Call) and
                      self.get_func_name(node.func) == 'format')
 
         return is_bin_op or is_format
@@ -446,21 +446,21 @@ class NoModuleChecker(misc.PylintOdooChecker):
                             'renamed-field-parameter', node=node,
                             args=(argument.arg, deprecated[argument.arg])
                         )
-                if isinstance(argument_aux, astroid.CallFunc) and \
+                if isinstance(argument_aux, astroid.Call) and \
                         isinstance(argument_aux.func, astroid.Name) and \
                         argument_aux.func.name == '_':
                     self.add_message('translation-field', node=argument_aux)
                 index += 1
         # Check cr.commit()
-        if isinstance(node, astroid.CallFunc) and \
-                isinstance(node.func, astroid.Getattr) and \
+        if isinstance(node, astroid.Call) and \
+                isinstance(node.func, astroid.Attribute) and \
                 node.func.attrname == 'commit' and \
                 self.get_cursor_name(node.func) in self.config.cursor_expr:
             self.add_message('invalid-commit', node=node)
 
         # Call the message_post()
-        if (isinstance(node, astroid.CallFunc) and
-                isinstance(node.func, astroid.Getattr) and
+        if (isinstance(node, astroid.Call) and
+                isinstance(node.func, astroid.Attribute) and
                 node.func.attrname == 'message_post'):
             for arg in itertools.chain(node.args, node.keywords or []):
                 if isinstance(arg, astroid.Keyword):
@@ -530,8 +530,8 @@ class NoModuleChecker(misc.PylintOdooChecker):
                     args=(wrong, right))
 
         # SQL Injection
-        if isinstance(node, astroid.CallFunc) and node.args and \
-                isinstance(node.func, astroid.Getattr) and \
+        if isinstance(node, astroid.Call) and node.args and \
+                isinstance(node.func, astroid.Attribute) and \
                 node.func.attrname in ('execute', 'executemany') and \
                 self.get_cursor_name(node.func) in self.config.cursor_expr:
 
@@ -567,7 +567,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
     def visit_dict(self, node):
         if not os.path.basename(self.linter.current_file) in \
                 settings.MANIFEST_FILES \
-                or not isinstance(node.parent, astroid.Discard):
+                or not isinstance(node.parent, astroid.Expr):
             return
         manifest_dict = ast.literal_eval(node.as_string())
 
@@ -669,7 +669,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
         if node.name in self.config.method_required_super:
             calls = [
                 call_func.func.name
-                for call_func in node.nodes_of_class((astroid.CallFunc,))
+                for call_func in node.nodes_of_class((astroid.Call,))
                 if isinstance(call_func.func, astroid.Name)]
             if 'super' not in calls:
                 self.add_message('method-required-super', node=node,
@@ -716,7 +716,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
     @utils.check_messages('attribute-deprecated')
     def visit_assign(self, node):
         node_left = node.targets[0]
-        if isinstance(node_left, astroid.node_classes.AssName):
+        if isinstance(node_left, astroid.AssignName):
             if node_left.name in self.config.attribute_deprecated:
                 self.add_message('attribute-deprecated',
                                  node=node_left, args=(node_left.name,))
@@ -743,11 +743,11 @@ class NoModuleChecker(misc.PylintOdooChecker):
 
     def get_func_name(self, node):
         func_name = isinstance(node, astroid.Name) and node.name or \
-            isinstance(node, astroid.Getattr) and node.attrname or ''
+            isinstance(node, astroid.Attribute) and node.attrname or ''
         return func_name
 
     def get_func_lib(self, node):
-        if isinstance(node, astroid.Getattr) and \
+        if isinstance(node, astroid.Attribute) and \
                 isinstance(node.expr, astroid.Name):
             return node.expr.name
         return ""
@@ -766,7 +766,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
             # ignore empty raise
             return
         expr = node.exc
-        if not isinstance(expr, astroid.CallFunc):
+        if not isinstance(expr, astroid.Call):
             # ignore raise without a call
             return
         if not expr.args:
@@ -774,7 +774,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
         func_name = self.get_func_name(expr.func)
 
         argument = expr.args[0]
-        if isinstance(argument, astroid.CallFunc) and \
+        if isinstance(argument, astroid.Call) and \
                 'format' == self.get_func_name(argument.func):
             argument = argument.func.expr
         elif isinstance(argument, astroid.BinOp):
@@ -790,7 +790,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
     def get_cursor_name(self, node):
         expr_list = []
         node_expr = node.expr
-        while isinstance(node_expr, astroid.Getattr):
+        while isinstance(node_expr, astroid.Attribute):
             expr_list.insert(0, node_expr.attrname)
             node_expr = node_expr.expr
         if isinstance(node_expr, astroid.Name):

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -240,8 +240,15 @@ class WrapperModuleChecker(PylintOdooChecker):
             r"(?P<file>^[\w|\-|\.|/ \\]+):?(?P<lineno>\d+)?:?(?P<colno>\d+)?"
         fregex = re.compile(fregex_str)
         fmatch = fregex.match(first_arg)
-        msg = self.linter.msgs_store.check_message_id(msg_code).msg.\
-            strip('"\' ')
+        # pylint 2.0 renamed check_message_id to get_message_definition in:
+        # https://github.com/PyCQA/pylint/commit/5ccbf9eaa54c0c302c9180bdfb745566c16e416d  # noqa
+        msgs_store = self.linter.msgs_store
+        if hasattr(msgs_store, 'check_message_id'):
+            get_message_definition = msgs_store.check_message_id
+        else:
+            get_message_definition = msgs_store.get_message_definition
+
+        msg = get_message_definition(msg_code).msg.strip('"\' ')
         if not fmatch or not msg.startswith(r"%s"):
             return msg_args
         module_path = os.path.dirname(self.odoo_node.file)

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -183,7 +183,7 @@ class PylintOdooChecker(BaseChecker):
 
     def add_message(self, msg_id, line=None, node=None, args=None,
                     confidence=UNDEFINED):
-        version = (self.manifest_dict.get('version')
+        version = (self.manifest_dict.get('version') or ''
                    if isinstance(self.manifest_dict, dict) else '')
         match = self.formatversion(version)
         short_version = match.group(1) if match else ''

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -82,10 +82,12 @@ def profiling(profile):
 
 class MainTest(unittest.TestCase):
     def setUp(self):
+        dummy_cfg = os.path.join(gettempdir(), 'nousedft.cfg')
+        open(dummy_cfg, "w").write("")
         self.default_options = [
             '--load-plugins=pylint_odoo', '--reports=no', '--msg-template='
             '"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"',
-            '--output-format=colorized',
+            '--output-format=colorized', '--rcfile=%s' % dummy_cfg,
         ]
         path_modules = os.path.join(
             os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
@@ -121,7 +123,10 @@ class MainTest(unittest.TestCase):
         sys.path.extend(paths)
         cmd = self.default_options + extra_params + paths
         with profiling(self.profile):
-            res = Run(cmd, exit=False)
+            try:
+                res = Run(cmd, do_exit=False)  # pylint2
+            except TypeError:
+                res = Run(cmd, exit=False)  # pylint1
         return res
 
     def test_10_path_dont_exist(self):

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -87,7 +87,7 @@ class MainTest(unittest.TestCase):
         self.default_options = [
             '--load-plugins=pylint_odoo', '--reports=no', '--msg-template='
             '"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"',
-            '--output-format=colorized', '--rcfile=%s' % dummy_cfg,
+            '--output-format=colorized', '--rcfile=%s' % os.devnull,
         ]
         path_modules = os.path.join(
             os.path.dirname(os.path.dirname(os.path.realpath(__file__))),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,14 @@
-astroid==1.6.3
-pylint==1.8.4
-pylint-plugin-utils==0.2.4
+astroid==1.6.5 ;python_version < '3'
+pylint==1.9.3 ;python_version < '3'
+
+astroid==2.0.4 ;python_version >= '3'
+pylint==2.1.1 ;python_version >= '3'
+
+pylint-plugin-utils==0.4
 docutils==0.14
-lxml>=2.3.2
+lxml>=4.2.3
 Pygments==2.2
-restructuredtext_lint==1.1
+restructuredtext_lint==1.1.3
 isort==4.3.4
 whichcraft
 rfc3986

--- a/tox.ini
+++ b/tox.ini
@@ -2,24 +2,11 @@
 envlist = clean, py27-pylint19, py35-pylint2, py37-pylint2, profile-stats
 skip_missing_interpreters = true
 
-[base]
-deps =
-   pylint-plugin-utils==0.4
-   docutils==0.14
-   lxml>=4.2.3
-   Pygments==2.2
-   restructuredtext_lint==1.1.3
-   isort==4.3.4
+[testenv]
+deps = -r{toxinidir}/requirements.txt
    # Test deps
    coveralls
    whichcraft
-
-[testenv]
-deps =
-    py27-pylint19: pylint==1.9.3
-    py35-pylint2: pylint==2.1.1
-    py37-pylint2: pylint==2.1.1
-   {[base]deps}
 setenv =
     PYLINT_ODOO_STATS = {toxinidir}/.cprofile_{envname}
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,35 +1,24 @@
 [tox]
-envlist = clean,py27-pylint{14,20}, py35-pylint{14,20}, py37-pylint{14,20}, profile-stats
+envlist = clean, py27-pylint19, py35-pylint2, py37-pylint2, profile-stats
 skip_missing_interpreters = true
 
 [base]
 deps =
-   pylint-plugin-utils==0.2.4
-   docutils==0.12
-   lxml>=2.3.2
-   Pygments==2.0.2
-   restructuredtext_lint==0.12.2
-   isort==4.2.5
+   pylint-plugin-utils==0.4
+   docutils==0.14
+   lxml>=4.2.3
+   Pygments==2.2
+   restructuredtext_lint==1.1.3
+   isort==4.3.4
    # Test deps
    coveralls
    whichcraft
 
 [testenv]
 deps =
-    py27-pylint14: astroid==1.4.8
-    py27-pylint14: pylint==1.6.4
-    py27-pylint20: git+https://github.com/PyCQA/astroid@9979615#egg=astroid
-    py27-pylint20: git+https://github.com/PyCQA/pylint@05cc9a7#egg=pylint
-
-    py35-pylint14: astroid==1.4.8
-    py35-pylint14: pylint==1.6.4
-    py35-pylint20: git+https://github.com/PyCQA/astroid@9979615#egg=astroid
-    py35-pylint20: git+https://github.com/PyCQA/pylint@05cc9a7#egg=pylint
-
-    py37-pylint14: astroid==1.4.8
-    py37-pylint14: pylint==1.6.4
-    py37-pylint20: git+https://github.com/PyCQA/astroid@9979615#egg=astroid
-    py37-pylint20: git+https://github.com/PyCQA/pylint@05cc9a7#egg=pylint
+    py27-pylint19: pylint==1.9.3
+    py35-pylint2: pylint==2.1.1
+    py37-pylint2: pylint==2.1.1
    {[base]deps}
 setenv =
     PYLINT_ODOO_STATS = {toxinidir}/.cprofile_{envname}


### PR DESCRIPTION
* Old classes were removed for new versions and 1.9 is using a dual compatibility.:
  - https://github.com/PyCQA/astroid/blob/eaef0dbedb32ea9540505db6450454b5e8dbd10b/astroid/node_classes.py#L4261-L4267

* Remove python-lxml apt package since that new lxml is using wheels and travis is using pip cache

* Update compatibility with py3.7

* Use a dummy pylint configuration file in order to avoid using the default one from the HOME (Useful for local testing)

* pylint2 is not compatible with python<3 anymore so removing that cases from tox and travis

* pylint2 renamed `check_message_id` to `get_message_definition` in:
   - https://github.com/PyCQA/pylint/commit/5ccbf9eaa54c0c302c9180bdfb745566c16e416d