### PR TITLE
[IMP] file-not-used: Ignore unused files into the import directory

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -833,7 +833,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
         referenced_files = set(self._get_manifest_referenced_files()).union(
             set(self._get_xml_referenced_files())
         )
-        excluded_dirs = ['static', 'test', 'tests', 'migrations']
+        excluded_dirs = ['static', 'test', 'tests', 'migrations', 'import']
         no_referenced_files = [
             f for f in (module_files - referenced_files)
             if f.split(os.path.sep)[0] not in excluded_dirs

--- a/pylint_odoo/test_repo/eleven_module/import/not_used_from_manifest.xml
+++ b/pylint_odoo/test_repo/eleven_module/import/not_used_from_manifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Even though this file isn't referenced from the manifest, this shouldn't fail,
+        because it's into the "import" folder
+    -->
+</odoo>


### PR DESCRIPTION
If there are data files into the "import" directory, e.g. XML/CSV,
they are probably intended to be used by the import python script, hence
they won't be referenced from the manifest.

This covers the case when there is complicated structure, or validation
that needs to be imported from modules init hook, and file is delivered
along with the module.

This commit causes the lint to ignore files located into the
"import" directory.

This is an extension of logics implemented in [commit](https://github.com/OCA/pylint-odoo/commit/a827027a939e20ed5591353216d163f08c88a930) made by @luisg123v.

cc @moylop260, @pedrobaeza: Please take a minute to review this small change. Thanks