### PR TITLE
Add fuzzy to ES globals

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -2,6 +2,7 @@
   "globals": {
     "$": false,
     "_": false,
+    "fuzzy": false,
     "jQuery": false,
     "moment": false,
     "odoo": false,


### PR DESCRIPTION
See it is globally enabled here: https://github.com/odoo/odoo/blob/12.0/addons/web/static/lib/fuzzy-master/fuzzy.js

@Tecnativa