### PR TITLE
[REF] missing-import-error: Check enabled just for odoo <= 11.0

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -241,6 +241,12 @@ class ModuleChecker(misc.WrapperModuleChecker):
         }),
     )
 
+    odoo_check_versions = {
+        'missing-import-error': {
+            'max_odoo_version': '11.0',
+        },
+    }
+
     class_inherit_names = []
 
     @utils.check_messages('consider-merging-classes-inherited')

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -294,6 +294,23 @@ class MainTest(unittest.TestCase):
         expected_errors['manifest-required-author'] = 3
         self.assertDictEqual(real_errors, expected_errors)
 
+    def test_120_import_error_skip(self):
+        """Missing import error skipped for >=12.0"""
+        extra_params = [
+            '--valid_odoo_versions=11.0',
+            '--disable=all',
+            '--enable=missing-import-error',
+        ]
+        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        real_errors_110 = pylint_res.linter.stats['by_msg']
+        self.assertEqual(self.expected_errors.get('missing-import-error'),
+                         real_errors_110.get('missing-import-error'))
+
+        extra_params[0] = '--valid_odoo_versions=12.0'
+        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        real_errors_120 = pylint_res.linter.stats['by_msg']
+        self.assertFalse(real_errors_120)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This check is deprecated since:
 - https://github.com/odoo/odoo/commit/8226aa1db828d2a559c7ffaa31a27ef3e5ba4d0b

Fix https://github.com/OCA/pylint-odoo/issues/222

cc @pedrobaeza @Yajo 