### PR TITLE
[DEL] require-jsdoc, keep require-valid-jsdoc

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -231,15 +231,6 @@
     "quote-props": "off",
     "quotes": "off",
     "radix": "error",
-    "require-jsdoc": ["warn", {
-      "require": {
-        "FunctionDeclaration": true,
-        "MethodDefinition": true,
-        "ClassDeclaration": true,
-        "ArrowFunctionExpression": true,
-        "FunctionExpression": true
-      }
-    }],
     "require-yield": "error",
     "rest-spread-spacing": "off",
     "semi": [


### PR DESCRIPTION
@Yajo where did you encouter problems with this? I tested with my python2 and 3 installation, and both nicely give me nothing if there's no jsdoc, and an error if I fill in a wrong one. That's what we want, right?