### PR TITLE
[REF] manifest-required-authors: Support old deprecated parameter

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -279,6 +279,14 @@ class NoModuleChecker(misc.PylintOdooChecker):
             'default': DFTL_MANIFEST_REQUIRED_AUTHORS,
             'help': 'Author names, at least one is required in manifest file.'
         }),
+        ('manifest_required_author', {
+            'type': 'string',
+            'metavar': '<string>',
+            'default': '',
+            'help': ('Name of author required in manifest file. '
+                     'This parameter is deprecated use '
+                     '"manifest_required_authors" instead.')
+        }),
         ('manifest_required_keys', {
             'type': 'csv',
             'metavar': '<comma separated values>',
@@ -580,7 +588,12 @@ class NoModuleChecker(misc.PylintOdooChecker):
         else:
             # Check author required
             authors = set([auth.strip() for auth in author.split(',')])
-            required_authors = set(self.config.manifest_required_authors)
+
+            if self.config.manifest_required_author:
+                # Support compatibility for deprecated attribute
+                required_authors = set((self.config.manifest_required_author,))
+            else:
+                required_authors = set(self.config.manifest_required_authors)
             if not (authors & required_authors):
                 # None of the required authors is present in the manifest
                 # Authors will be printed as 'author1', 'author2', ...

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -294,6 +294,17 @@ class MainTest(unittest.TestCase):
         expected_errors['manifest-required-author'] = 3
         self.assertDictEqual(real_errors, expected_errors)
 
+        # Testing deprecated attribute
+        extra_params[0] = ('--manifest_required_author='
+                           'Odoo Community Association (OCA)')
+        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        real_errors = pylint_res.linter.stats['by_msg']
+        expected_errors_deprecated = {
+            'manifest-required-author': (
+                EXPECTED_ERRORS['manifest-required-author']),
+        }
+        self.assertDictEqual(real_errors, expected_errors_deprecated)
+
     def test_120_import_error_skip(self):
         """Missing import error skipped for >=12.0"""
         extra_params = [


### PR DESCRIPTION
Fix https://github.com/OCA/pylint-odoo/issues/232

cc @lmignon 