### PR TITLE
[ADD] print-used: Use _logger instead of print

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -52,6 +52,7 @@ EXPECTED_ERRORS = {
     'odoo-addons-relative-import': 4,
     'old-api7-method-defined': 2,
     'openerp-exception-warning': 3,
+    'print-used': 1,
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,
     'sql-injection': 18,


### PR DESCRIPTION
Since that new version of pylint is not considering a check for
"print()" in python3