### PR TITLE
Allow console statements

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -22,7 +22,7 @@
     "no-class-assign": "error",
     "no-cond-assign": "error",
     "no-confusing-arrow": "error",
-    "no-console": "error",
+    "no-console": "off",
     "no-const-assign": "error",
     "no-constant-condition": "error",
     "no-continue": "off",

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -31,7 +31,7 @@ EXPECTED_ERRORS = {
     'file-not-used': 6,
     'incoherent-interpreter-exec-perm': 3,
     'invalid-commit': 4,
-    'javascript-lint': 25,
+    'javascript-lint': 24,
     'license-allowed': 1,
     'manifest-author-string': 1,
     'manifest-deprecated-key': 1,


### PR DESCRIPTION

These are required in Odoo in order to mark a tour as failed manually.

It can also be helpful to log some interesting details for developers that shouldn't matter for users. Odoo uses it, in fact.

See https://github.com/OCA/website/pull/627#discussion_r285006941 where this was discovered.