### PR TITLE
[FIX] .travis.yml: Upgrade nvm version supported for eslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 
 
 install:
-    - nvm install 6  # Update nodejs version to 6.latest, required by eslint
+    - nvm install 11  # Update nodejs version to 11.latest, required by eslint
     # Remove packages installed from addons-apt-packages of travis file
     - sed -i '/node/d' ${TRAVIS_BUILD_DIR}/install.sh
     - sed -i '/pip install ./d' ${TRAVIS_BUILD_DIR}/install.sh

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ whitelist_externals =
 
 commands =
     npm install eslint
+    eslint --version
     coverage run setup.py test
     coverage report -m
 


### PR DESCRIPTION
Currently, travis is red...
This PR allow us to debug from travis build if eslint was installed correctly.

Fix related for MQT: https://github.com/OCA/maintainer-quality-tools/pull/607