### PR TITLE
Revert "[ADD] method-default prefix"

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -190,11 +190,6 @@ ODOO_MSGS = {
         'development-status-allowed',
         settings.DESC_DFLT
     ),
-    'C%d12' % settings.BASE_NOMODULE_ID: (
-        'Name of default method should start with "_default_"',
-        'method-default',
-        settings.DESC_DFLT
-    ),
     'R%d10' % settings.BASE_NOMODULE_ID: (
         'Method defined with old api version 7',
         'old-api7-method-defined',
@@ -440,7 +435,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
                           'renamed-field-parameter',
                           'translation-required',
                           'translation-contains-variable',
-                          'print-used', 'method-default'
+                          'print-used',
                           )
     def visit_call(self, node):
         infer_node = utils.safe_infer(node.func)
@@ -469,8 +464,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
                 if isinstance(argument, astroid.Keyword):
                     argument_aux = argument.value
                     deprecated = self.config.deprecated_field_parameters
-                    if argument.arg in ['compute', 'search', 'inverse',
-                                        'default'] and \
+                    if argument.arg in ['compute', 'search', 'inverse'] and \
                             isinstance(argument_aux, astroid.Const) and \
                             isinstance(argument_aux.value, string_types) and \
                             not argument_aux.value.startswith(

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -42,7 +42,6 @@ EXPECTED_ERRORS = {
     'method-inverse': 1,
     'method-required-super': 8,
     'method-search': 1,
-    'method-default': 1,
     'missing-import-error': 7,
     'missing-manifest-dependency': 5,
     'missing-newline-extrafiles': 4,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -35,9 +35,6 @@ class TestModel(models.Model):
         search='_search_name',  # good search method name
         inverse='_inverse_name',  # good inverse method name
     )
-    name_default = fields.Char(
-        default='_default_name'  # good default method name
-    )
 
     # Imported openerp.fields use Char (Upper case)
     other_field = fields.char(
@@ -46,9 +43,6 @@ class TestModel(models.Model):
         compute='my_method_compute',  # bad compute method name
         search='my_method_search',  # bad search method name
         inverse='my_method_inverse',  # bad inverse method name
-    )
-    other_name_default = fields.Char(
-        default='get_default'  # bad default method name
     )
     compute_none = fields.Char(compute=None)
 


### PR DESCRIPTION
This reverts commit 586c6819539a57aae847748e47518ffd757ecc7d.
From pull request https://github.com/OCA/pylint-odoo/pull/250

In order to fix https://github.com/OCA/pylint-odoo/issues/253
and work better this new check.