### PR TITLE
[ADD] context-overridden: Better using kwargs instead of dictionary

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -19,6 +19,7 @@ EXPECTED_ERRORS = {
     'attribute-deprecated': 3,
     'class-camelcase': 1,
     'consider-merging-classes-inherited': 2,
+    'context-overridden': 3,
     'copy-wo-api-one': 2,
     'create-user-wo-reset-password': 1,
     'dangerous-filter-wo-user': 1,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -65,6 +65,14 @@ class TestModel(models.Model):
             fields.Datetime.context_timestamp(self,
                                               timestamp=fields.Datetime.now())
         )
+        self.with_context({'overwrite_context': True}).write({})
+        ctx = {'overwrite_context': True}
+        self.with_context(ctx).write({})
+        ctx2 = ctx
+        self.with_context(ctx2).write({})
+
+        self.with_context(**ctx).write({})
+        self.with_context(overwrite_context=False).write({})
         return date
 
     my_ok_field = fields.Float(


### PR DESCRIPTION
More info about see docstring of the method:
 - https://github.com/odoo/odoo/blob/ff3064258a320e4008b3fb52a149e6751ae1e7f5/odoo/models.py#L5086-L5105

Using
  - `self.with_context({'key': 'value'})`

The original context is overridden

It should be:
  - `self.with_context(**{'key': 'value'})`
  - `self.with_context(key='value')`

If you need to override the full context only silent this check using:
  - `self.with_context({'key': 'value'})  # pylint: disable=context-overridden`
In order to allow an explicit overridden

Requested by @yajo from:
 - https://github.com/odoo/odoo/pull/36164

- [x] Add unittest
