### PR TITLE
[FIX] rst-syntax-error: Using a 0 by default if line None is returned

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -431,7 +431,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
                     # Skip directive errors
                     continue
                 self.msg_args.append((
-                    "%s:%d" % (rst_file, error.line),
+                    "%s:%d" % (rst_file, error.line or 0),
                     msg.strip('\n').replace('\n', '|')))
         if self.msg_args:
             return False


### PR DESCRIPTION
cc @eilst 
FIX https://github.com/OCA/pylint-odoo/issues/262