### PR TITLE
WIP: [FIX] sql-injection: Supports multiple private args

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -425,20 +425,17 @@ class NoModuleChecker(misc.PylintOdooChecker):
     def _check_node_for_sqli_risk(self, node):
         is_bin_op = False
         if isinstance(node, astroid.BinOp) and node.op in ('%', '+'):
-            # Ignoring execute("..." % self._table)
-            #          execute("..." % self._where())
-            if isinstance(node.right, astroid.Attribute):
-                is_bin_op = not self._is_private_node(node.right)
-
             # Ignoring execute("..." % (self._table, ...))
             #          execute("..." % (self._where(), ...))
-            elif isinstance(node.right, astroid.Tuple):
+            if isinstance(node.right, astroid.Tuple):
                 for elt in node.right.elts:
                     if not self._is_private_node(elt):
                         is_bin_op = True
                         break
             else:
-                is_bin_op = True
+                # Ignoring execute("..." % self._table)
+                #          execute("..." % self._where())
+                is_bin_op = not self._is_private_node(node.right)
 
         is_format = False
         if (isinstance(node, astroid.Call) and


### PR DESCRIPTION
Now ignores execute("..." % (self._table, ...))
and execute("...".format(table=self._table)) or execute("...".format(self._table))"

Since that it is private argument (no user input) and it is a valid
option to execute queries without sql-injection

Fixing the following valid case of use:
 - https://github.com/OCA/l10n-usa/pull/51/files#diff-1003d0a8ef76ca3b90e7581aae489425R57