### PR TITLE
[ADD] Possibility of package name include dots

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -405,7 +405,8 @@ class ModuleChecker(misc.WrapperModuleChecker):
         if isinstance(node, astroid.ImportFrom) and (node.level or 0) >= 1:
             return
         if module_name not in py_ext_deps and \
-                module_name.split('.')[0] not in py_ext_deps:
+                module_name.split('.')[0] not in py_ext_deps and \
+                not any(dep in module_name for dep in py_ext_deps):
             self.add_message('missing-manifest-dependency', node=node,
                              args=(module_name,))
 


### PR DESCRIPTION
The error "missing-manifest-dependency" is raised in an import if the module name in the import is not listed in the python external dependencies, in the __manifest__.py file. For example, in the following import statement, the module "dateutil" should be listed in the python external dependencies:

from dateutil.relativedelta import relativedelta

The verification for this is made checking if either the module name (in this case "dateutil.relativedelta") or the substring before the first dot ("dateutil") is in the python external dependencies and else it is raised the error "missing-manifest-dependency". The problem with this verification is the possibility of the module name contain dots in its original name. For example, in my case, I'm trying to do the following import:

from erpbrasil.base.misc import punctuation_rm

In this case, the name of the external dependency library is "erpbrasil.base", so the already existing checks would raise the error "missing-manifest-dependency", even though it works and it is an correct import clause. My commit treats this problem, verifying if there is at least one of the python external dependencies string that is in the module name of the import (in this case it verifies if the name "erpbrasil.base" is in the module name "erpbrasil.base.misc"), and not raising the error if there is.
