### PR TITLE
[REF] .travis.yml: Using py3.7 stable instead of dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: 3.5
       env:
         TOXENV=py35-pylint2
-    - python: 3.7-dev
+    - python: 3.7
       env:
         TOXENV=py37-pylint2
 


### PR DESCRIPTION
Since that https://docs.travis-ci.com/user/languages/python/#specifying-python-versions is updated to use 3.7