### PR TITLE
[FIX] rst_lint: Using UTF-8 encoding by default

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -370,7 +370,7 @@ class WrapperModuleChecker(PylintOdooChecker):
         :param fname: String with file name path to check
         :return: Return list of errors.
         """
-        return rst_lint(fname)
+        return rst_lint(fname, encoding='UTF-8')
 
     def npm_which_module(self, module):
         module_bin = which(module)


### PR DESCRIPTION
In order to avoid errors using a clean environment without codecs configured.

It is fixing 
```bash
Traceback (most recent call last):
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint/__init__.py", line 20, in run_pylint
    Run(sys.argv[1:])
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint/lint.py", line 1628, in __init__
    linter.check(args)
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint/lint.py", line 943, in check
    self._do_check(files_or_modules)
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint/lint.py", line 1075, in _do_check
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint/lint.py", line 1158, in check_astroid_module
    walker.walk(ast_node)
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint/utils.py", line 1300, in walk
    cb(astroid)
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint_odoo/misc.py", line 197, in visit_module
    self.wrapper_visit_module(node)
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint_odoo/misc.py", line 183, in wrapper_visit_module
    if not check_method():
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint_odoo/checkers/modules_odoo.py", line 420, in _check_rst_syntax_error
    os.path.join(self.module_path, rst_file))
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/pylint_odoo/misc.py", line 373, in check_rst_syntax
    return rst_lint(fname)
  File "/root/.cache/pre-commit/repov9q9gh9a/py_env-python3/lib/python3.6/site-packages/restructuredtext_lint/lint.py", line 98, in lint_file
    content = f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 3238: ordinal not in range(128)
```

If you are using a README.rst like this one:
 - https://github.com/OCA/product-attribute/blob/9767e2da0962164b8730ad10ec9d3765cdd4959d/product_supplierinfo_for_customer/README.rst
