### PR TITLE
[FIX] Visit module: manage odoo subdirectories

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -151,8 +151,10 @@ class PylintOdooChecker(BaseChecker):
                 os.path.dirname(self.odoo_node.file))
             with open(self.manifest_file) as f_manifest:
                 self.manifest_dict = ast.literal_eval(f_manifest.read())
-        elif self.odoo_node and not os.path.dirname(self.odoo_node.file) in \
-                os.path.dirname(node.file):
+        elif self.odoo_node and os.path.commonprefix(
+                [os.path.dirname(self.odoo_node.file),
+                 os.path.dirname(node.file)]) != os.path.dirname(
+                self.odoo_node.file):
             # It's not a sub-module python of a odoo module and
             #  it's not a odoo module
             self.odoo_node = None


### PR DESCRIPTION
Better way to check whether a path is a path of a subdirectoy of a Odoo module.
Before, '/a/b/cc/d' was considered as a subdirectoy of '/a/b/c' because `'/a/b/c' in '/a/b/cc/d' == True`.

Now:

```python
os.path.commonprefix(["/a/b/c", "/a/b/cc/d"]) == "/a/b"  # not a subdirectory
os.path.commonprefix(["/a/b/c", "/a/b/c/d"]) == "/a/b/c"  # subdirectory
```