### PR TITLE
[FIX] get_manifest_file: Get manifest file even if it is checking only one file and not the module like pre-commit uses

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -74,7 +74,7 @@ class PylintOdooChecker(BaseChecker):
     odoo_node = None
     odoo_module_name = None
     manifest_file = None
-    manifest_dict = None
+    manifest_dict = {}
 
     def formatversion(self, string):
         valid_odoo_versions = self.linter._all_options[
@@ -86,16 +86,25 @@ class PylintOdooChecker(BaseChecker):
                 valid_odoo_versions=valid_odoo_versions))
         return re.match(self.config.manifest_version_format_parsed, string)
 
-    def get_manifest_file(self, node_file):
+    def get_manifest_file(self, node):
         """Get manifest file path
         :param node_file: String with full path of a python module file.
         :return: Full path of manifest file if exists else return None"""
-        if os.path.basename(node_file) == '__init__.py':
-            for manifest_basename in settings.MANIFEST_FILES:
-                manifest_file = os.path.join(
-                    os.path.dirname(node_file), manifest_basename)
-                if os.path.isfile(manifest_file):
-                    return manifest_file
+        if not node.file or not os.path.isfile(node.file):
+            return
+
+        # Get 'module' part from node.name 'module.models.file'
+        module_path = node.file
+        node_name = node.name
+        if os.path.basename(node.file) == '__init__.py':
+            node_name += '.__init__'
+        for depth in range(node_name.count('.')):
+            module_path = os.path.dirname(module_path)
+
+        for manifest_basename in settings.MANIFEST_FILES:
+            manifest_file = os.path.join(module_path, manifest_basename)
+            if os.path.isfile(manifest_file):
+                return manifest_file
 
     def set_ext_files(self):
         """Create `self.ext_files` dictionary with {extension_file: [files]}
@@ -121,7 +130,8 @@ class PylintOdooChecker(BaseChecker):
                     self.ext_files.setdefault(fext, []).append(fname_rel)
 
     def set_caches(self):
-        if self.odoo_node:
+        self.ext_files = {}
+        if self.is_main_odoo_module:
             self.set_ext_files()
 
     def clear_caches(self):
@@ -143,12 +153,12 @@ class PylintOdooChecker(BaseChecker):
         :param node: A astroid.scoped_nodes.Module
         :return: None
         """
-        manifest_file = self.get_manifest_file(node.file)
+        manifest_file = self.get_manifest_file(node)
         if manifest_file:
             self.manifest_file = manifest_file
             self.odoo_node = node
             self.odoo_module_name = os.path.basename(
-                os.path.dirname(self.odoo_node.file))
+                os.path.dirname(manifest_file))
             with open(self.manifest_file) as f_manifest:
                 self.manifest_dict = ast.literal_eval(f_manifest.read())
         elif self.odoo_node and not os.path.dirname(self.odoo_node.file) in \
@@ -157,10 +167,10 @@ class PylintOdooChecker(BaseChecker):
             #  it's not a odoo module
             self.odoo_node = None
             self.odoo_module_name = None
-            self.manifest_dict = None
+            self.manifest_dict = {}
             self.manifest_file = None
         self.is_main_odoo_module = False
-        if self.odoo_node and self.odoo_node.file == node.file:
+        if self.manifest_file and node.name.count('.') == 0:
             self.is_main_odoo_module = True
         self.node = node
         self.module_path = os.path.dirname(node.file)
@@ -279,7 +289,7 @@ class WrapperModuleChecker(PylintOdooChecker):
         msg = get_message_definitions(msg_code)[0].msg.strip('"\' ')
         if not fmatch or not msg.startswith(r"%s"):
             return msg_args
-        module_path = os.path.dirname(self.odoo_node.file)
+        module_path = os.path.dirname(self.manifest_file or node.file)
         fname = fmatch.group('file')
         fpath = os.path.join(module_path, fname)
         node.file = fpath if os.path.isfile(fpath) else module_path


### PR DESCRIPTION
Closes https://github.com/OCA/pylint-odoo/issues/282