### PR TITLE
[REF] missing-import-error: Add new packages for Odoo v13.0

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -168,7 +168,7 @@ DFLT_IMPORT_NAME_WHITELIST = [
     # self-odoo
     'odoo', 'openerp',
     # Known external packages of odoo
-    'PIL', 'anybox.testing.openerp', 'argparse', 'babel',
+    'PIL', 'PyPDF2', 'anybox.testing.openerp', 'argparse', 'babel', 'chardet',
     'dateutil', 'decorator', 'docutils', 'faces', 'feedparser',
     'gdata', 'gevent', 'greenlet', 'jcconv', 'jinja2',
     'ldap', 'lxml', 'mako', 'markupsafe', 'mock', 'odf',
@@ -176,7 +176,7 @@ DFLT_IMPORT_NAME_WHITELIST = [
     'psutil', 'psycogreen', 'psycopg2', 'pyPdf', 'pychart',
     'pydot', 'pyparsing', 'pytz', 'qrcode', 'reportlab',
     'requests', 'serial', 'simplejson', 'six', 'suds',
-    'unittest2', 'usb', 'vatnumber', 'vobject', 'werkzeug',
+    'unittest2', 'urllib3', 'usb', 'vatnumber', 'vobject', 'werkzeug',
     'wsgiref', 'xlsxwriter', 'xlwt', 'yaml',
 ]
 DFTL_JSLINTRC = os.path.join(


### PR DESCRIPTION
Identified running:

 - `PYTHONPATH=~/pylint-odoo python3 -m pylint -d all -e missing-import-error,missing-manifest-dependency --load-plugins=pylint_odoo addons/* odoo/addons/*`


 - [PyPDF2](
https://github.com/odoo/odoo/blob/47707e1b099195487fd3d3e0ae012e4aed5a9bc5/requirements.txt#L33)
- [chardet](https://github.com/odoo/odoo/blob/47707e1b099195487fd3d3e0ae012e4aed5a9bc5/requirements.txt#L2)
- [urllib3 (requests dependency)](https://github.com/odoo/odoo/blob/47707e1b099195487fd3d3e0ae012e4aed5a9bc5/requirements.txt#L40)