### PR TITLE
[IMP] Add openupgradelib as a whitelist.

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -178,6 +178,8 @@ DFLT_IMPORT_NAME_WHITELIST = [
     'requests', 'serial', 'simplejson', 'six', 'suds',
     'unittest2', 'urllib3', 'usb', 'vatnumber', 'vobject', 'werkzeug',
     'wsgiref', 'xlsxwriter', 'xlwt', 'yaml',
+    # OpenUpgrade migration
+    'openupgradelib'
 ]
 DFTL_JSLINTRC = os.path.join(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))),


### PR DESCRIPTION
Lately i had some travis fails due to openupgradelib is not in the external dependencies, i don't know if we should add it to all the modules that contains migration or we can add it separately in the repositories, in isort.cfg
https://github.com/OCA/pylint-odoo/issues/247
or will work with the changes i did.

https://travis-ci.org/github/OCA/commission/jobs/707123086