### PR TITLE
[REF] po-msgstr-variables: Check if there is missing 'module:' comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ coverage.xml
 
 # Translations
 *.mo
-*.pot
 
 # Pycharm
 .idea

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -54,7 +54,7 @@ EXPECTED_ERRORS = {
     'odoo-addons-relative-import': 4,
     'old-api7-method-defined': 2,
     'openerp-exception-warning': 3,
-    'po-syntax-error': 1,
+    'po-syntax-error': 2,
     'po-msgstr-variables': 6,
     'print-used': 1,
     'redundant-modulename-xml': 1,

--- a/pylint_odoo/test_repo/broken_module/i18n/broken_module.pot
+++ b/pylint_odoo/test_repo/broken_module/i18n/broken_module.pot
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 1985-04-14 17:12+0000\n"
+"PO-Revision-Date: 1985-04-14 02:03+0000\n"
+"Last-Translator: Moisés López <moylop260@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+# Missing module: comment
+#: model:ir.model.fields,field_description:broken_module.field_description
+#: model:ir.model.fields,field_description:broken_module.field_wizard_description
+#, python-format
+msgid "Branch"
+msgstr ""

--- a/pylint_odoo/test_repo/test_module/i18n/fr.po
+++ b/pylint_odoo/test_repo/test_module/i18n/fr.po
@@ -87,3 +87,9 @@ msgstr ""
 #, python-format
 msgid "%s%% discount"
 msgstr "%s%%discount without space"
+
+#. module: test_module
+#: code:addons/test_module/__init__.py:10
+#, python-format
+#~ msgid "Obsolet msgid"
+#~ msgstr "Obsolet msgstr"


### PR DESCRIPTION
Odoo translation entries require the following comment
'#. module: MODULE'

If there is missing this comment the following issue could be reproduced:
 - https://github.com/odoo/odoo/pull/55083

But it is complex to detect where is the issue really.

This check helps to know where is the error.