### PR TITLE
[ADD] translation-positional-used: New check to valid the allow change the order of string formatting

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -232,6 +232,13 @@ ODOO_MSGS = {
         'print-used',
         settings.DESC_DFLT
     ),
+    'W%d20' % settings.BASE_NOMODULE_ID: (
+        'Translation method _(%s) is using positional string formatting. '
+        'Use named placeholder string formatting "_(%%(placeholder)s)" '
+        'or "_({placeholder})" instead.',
+        'translation-positional-used',
+        settings.DESC_DFLT
+    ),
     'F%d01' % settings.BASE_NOMODULE_ID: (
         'File "%s": "%s" not found.',
         'resource-not-exist',
@@ -484,7 +491,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
                           'renamed-field-parameter',
                           'translation-required',
                           'translation-contains-variable',
-                          'print-used',
+                          'print-used', 'translation-positional-used',
                           )
     def visit_call(self, node):
         infer_node = utils.safe_infer(node.func)
@@ -593,6 +600,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
                 and node.func.name == '_'
                 and node.args):
             wrong = ''
+            right = ''
             arg = node.args[0]
             # case: _('...' % (variables))
             if isinstance(arg, astroid.BinOp) and arg.op == '%':
@@ -611,10 +619,32 @@ class NoModuleChecker(misc.PylintOdooChecker):
                     for x in itertools.chain(arg.args, arg.keywords or [])])
                 right = '_(%s).format(%s)' % (
                     arg.func.expr.as_string(), params_as_string)
-            if wrong:
+            if wrong and right:
                 self.add_message(
                     'translation-contains-variable', node=node,
                     args=(wrong, right))
+
+            # translation-positional-used: Check "string to translate"
+            # to check %s or {} used
+            str2translate = arg.as_string()
+            extra_data = {}
+            msgid_args, msgid_kwargs = (
+                misc.WrapperModuleChecker.
+                _get_format_str_args_kwargs(str2translate, extra_data=extra_data))
+            is_positional = False
+            if extra_data['has_placeholders']:
+                if len(msgid_args) >= 2 and extra_data['has_positional']:
+                    is_positional = True
+            else:
+                printf_args = (
+                    misc.WrapperModuleChecker.
+                    _get_printf_str_args_kwargs(str2translate))
+                # Return tuple for %s and dict for %(varname)s
+                if isinstance(printf_args, tuple) and len(printf_args) >= 2:
+                    is_positional = True
+            if is_positional:
+                self.add_message('translation-positional-used',
+                                 node=node, args=(str2translate,))
 
         # SQL Injection
         if isinstance(node, astroid.Call) and node.args and \

--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -233,9 +233,8 @@ ODOO_MSGS = {
         settings.DESC_DFLT
     ),
     'W%d20' % settings.BASE_NOMODULE_ID: (
-        'Translation method _(%s) is using positional string formatting. '
-        'Use named placeholder string formatting "_(%%(placeholder)s)" '
-        'or "_({placeholder})" instead.',
+        'Translation method _(%s) is using positional string printf formatting. '
+        'Use named placeholder `_("%%(placeholder)s")` instead.',
         'translation-positional-used',
         settings.DESC_DFLT
     ),
@@ -625,24 +624,14 @@ class NoModuleChecker(misc.PylintOdooChecker):
                     args=(wrong, right))
 
             # translation-positional-used: Check "string to translate"
-            # to check %s or {} used
+            # to check "%s %s..." used where the position can't be changed
             str2translate = arg.as_string()
-            extra_data = {}
-            msgid_args, msgid_kwargs = (
+            printf_args = (
                 misc.WrapperModuleChecker.
-                _get_format_str_args_kwargs(str2translate, extra_data=extra_data))
-            is_positional = False
-            if extra_data['has_placeholders']:
-                if len(msgid_args) >= 2 and extra_data['has_positional']:
-                    is_positional = True
-            else:
-                printf_args = (
-                    misc.WrapperModuleChecker.
-                    _get_printf_str_args_kwargs(str2translate))
+                _get_printf_str_args_kwargs(str2translate))
+            if isinstance(printf_args, tuple) and len(printf_args) >= 2:
                 # Return tuple for %s and dict for %(varname)s
-                if isinstance(printf_args, tuple) and len(printf_args) >= 2:
-                    is_positional = True
-            if is_positional:
+                # Check just the following cases "%s %s..."
                 self.add_message('translation-positional-used',
                                  node=node, args=(str2translate,))
 

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -543,7 +543,7 @@ class WrapperModuleChecker(PylintOdooChecker):
         return xml_ids
 
     @staticmethod
-    def _get_format_str_args_kwargs(format_str, extra_data=None):
+    def _get_format_str_args_kwargs(format_str):
         """Get dummy args and kwargs of a format string
         e.g. format_str = '{} {} {variable}'
             dummy args = (0, 0)
@@ -552,18 +552,9 @@ class WrapperModuleChecker(PylintOdooChecker):
         Motivation to use format_str.format(*args, **kwargs)
         and validate if it was parsed correctly
         """
-        if extra_data is None:
-            extra_data = {}
-        extra_data.update({
-            'has_positional': False,
-            'has_numbered': False,
-            'has_named': False,
-            'has_placeholders': False,
-        })
         format_str_args = []
         format_str_kwargs = {}
         placeholders = []
-        has_named_vars = False
         for line in format_str.splitlines():
             try:
                 placeholders.extend(
@@ -577,21 +568,14 @@ class WrapperModuleChecker(PylintOdooChecker):
                     # append 0 to use max(0, 0, ...) == 0
                     # and identify that all args are unnumbered vs numbered
                     format_str_args.append(0)
-                    extra_data['has_positional'] = True
                 elif placeholder.isdigit():
                     # numbered "{0} {1} {2} {0}"
                     # append +1 to use max(1, 2) and know the quantity of args
                     # and identify that the args are numbered
-                    has_named_vars = True
                     format_str_args.append(int(placeholder) + 1)
-                    extra_data['has_numbered'] = True
                 else:
                     # named "{var0} {var1} {var2} {var0}"
-                    has_named_vars = True
                     format_str_kwargs[placeholder] = 0
-                    extra_data['has_named'] = True
-            if placeholders:
-                extra_data['has_placeholders'] = True
         if format_str_args:
             format_str_args = (range(len(format_str_args)) if max(format_str_args) == 0
                                else range(max(format_str_args)))

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -543,7 +543,7 @@ class WrapperModuleChecker(PylintOdooChecker):
         return xml_ids
 
     @staticmethod
-    def _get_format_str_args_kwargs(format_str):
+    def _get_format_str_args_kwargs(format_str, extra_data=None):
         """Get dummy args and kwargs of a format string
         e.g. format_str = '{} {} {variable}'
             dummy args = (0, 0)
@@ -552,9 +552,18 @@ class WrapperModuleChecker(PylintOdooChecker):
         Motivation to use format_str.format(*args, **kwargs)
         and validate if it was parsed correctly
         """
+        if extra_data is None:
+            extra_data = {}
+        extra_data.update({
+            'has_positional': False,
+            'has_numbered': False,
+            'has_named': False,
+            'has_placeholders': False,
+        })
         format_str_args = []
         format_str_kwargs = {}
         placeholders = []
+        has_named_vars = False
         for line in format_str.splitlines():
             try:
                 placeholders.extend(
@@ -568,14 +577,21 @@ class WrapperModuleChecker(PylintOdooChecker):
                     # append 0 to use max(0, 0, ...) == 0
                     # and identify that all args are unnumbered vs numbered
                     format_str_args.append(0)
+                    extra_data['has_positional'] = True
                 elif placeholder.isdigit():
                     # numbered "{0} {1} {2} {0}"
                     # append +1 to use max(1, 2) and know the quantity of args
                     # and identify that the args are numbered
+                    has_named_vars = True
                     format_str_args.append(int(placeholder) + 1)
+                    extra_data['has_numbered'] = True
                 else:
                     # named "{var0} {var1} {var2} {var0}"
+                    has_named_vars = True
                     format_str_kwargs[placeholder] = 0
+                    extra_data['has_named'] = True
+            if placeholders:
+                extra_data['has_placeholders'] = True
         if format_str_args:
             format_str_args = (range(len(format_str_args)) if max(format_str_args) == 0
                                else range(max(format_str_args)))

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -60,6 +60,7 @@ EXPECTED_ERRORS = {
     'translation-field': 2,
     'translation-required': 15,
     'translation-contains-variable': 10,
+    'translation-positional-used': 6,
     'use-vim-comment': 1,
     'wrong-tabs-instead-of-spaces': 2,
     'eval-referenced': 5,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -60,7 +60,7 @@ EXPECTED_ERRORS = {
     'translation-field': 2,
     'translation-required': 15,
     'translation-contains-variable': 10,
-    'translation-positional-used': 6,
+    'translation-positional-used': 5,
     'use-vim-comment': 1,
     'wrong-tabs-instead-of-spaces': 2,
     'eval-referenced': 5,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -249,16 +249,13 @@ class TestModel(models.Model):
         # string with parameters without name
         # so you can't change the order in the translation
         _('%s %d') % ('hello', 3)
-        _('{} {}') % ('hello', 3)
-        _('{} {:d}') % ('hello', 3)
+        _('%s %s') % ('hello', 'world')
 
         # Valid cases
-        _('{0} {1}') % ('hello', 3)
+        _('%(strname)s') % {'strname': 'hello'}
         _('%(strname)s %(intname)d') % {'strname': 'hello', 'intname': 3}
         _('%s') % 'hello'
         _('%d') % 3
-        _('{}') % 'hello'
-        _('{:d}') % 3
         return error_msg
 
     def my_method2(self, variable2):

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -245,6 +245,20 @@ class TestModel(models.Model):
         error_msg = _('Variable not translatable: {}'.format(variable1))
         error_msg = _('Variables not translatable: {}, {variable2}'.format(
             variable1, variable2=variable2))
+
+        # string with parameters without name
+        # so you can't change the order in the translation
+        _('%s %d') % ('hello', 3)
+        _('{} {}') % ('hello', 3)
+        _('{} {:d}') % ('hello', 3)
+
+        # Valid cases
+        _('{0} {1}') % ('hello', 3)
+        _('%(strname)s %(intname)d') % {'strname': 'hello', 'intname': 3}
+        _('%s') % 'hello'
+        _('%d') % 3
+        _('{}') % 'hello'
+        _('{:d}') % 3
         return error_msg
 
     def my_method2(self, variable2):


### PR DESCRIPTION
If you are using:
 - `_("Your %s %s is shipping") % ("red", "car")`

Better using:
 - `_("Your %(color)s %(item)s is shipping") % {"color": "red", "item": "car"}`

In order to allow other languages change the order
 - e.g. in Spanish: `"Su %(item)s %(color)s está enviándose"`

Fix https://github.com/OCA/pylint-odoo/issues/303