### PR TITLE
[12.0][REF] pylint-odoo: odoo-addons-relative-import does not apply in test dir

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -325,6 +325,15 @@ class ModuleChecker(misc.WrapperModuleChecker):
 
     def _get_odoo_module_imported(self, node):
         odoo_module = []
+        if self.manifest_file and hasattr(node.parent, 'file'):
+            relpath = os.path.relpath(
+                node.parent.file, os.path.dirname(self.manifest_file))
+            if os.path.dirname(relpath) == 'tests':
+                # import errors rules don't apply to the test files
+                # since these files are loaded only when running tests
+                # and in such a case your
+                # module and their external dependencies are installed.
+                return odoo_module
         if isinstance(node, astroid.ImportFrom) and \
                 ('openerp.addons' in node.modname or
                  'odoo.addons' in node.modname):

--- a/pylint_odoo/test_repo/eleven_module/tests/test_model1.py
+++ b/pylint_odoo/test_repo/eleven_module/tests/test_model1.py
@@ -1,5 +1,7 @@
 
 from odoo.tests.common import TransactionCase
+from odoo.addons.eleven_module.models import EleveModel
+from .no_exists import package
 
 # Even though astroid is not set as an external dependency, it should not fail,
 # because this is a test file
@@ -13,3 +15,9 @@ class TestModel(TransactionCase):
         super(TestModel, self).setUp()
         self.const = isinstance(astroid.Const, Const)
         self.bo = isinstance(astroid.BinOp, bo)
+
+    def method(self):
+        return package
+
+    def methodModel(self):
+        return EleveModel


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

It is more correct to use absolute imports in tests. Tests are not truly constitutive of the module, they just happen to be stored inside the module. Usually, in Python libs, they're stored outside of the package. Importantly, using the absolute import proves that the addon we develop works as a library too.

Current behavior before PR: pylint-odoo warns about relative imports in tests/*

Desired behavior after PR is merged: pylint-odoo does not warn about relative imports in tests/*

Fix #297 

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
