### PR TITLE
[ADD] pylint-odoo: add new check to maintainers key in manifest must be a list of str

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -132,6 +132,11 @@ ODOO_MSGS = {
         'sql-injection',
         settings.DESC_DFLT
     ),
+    'E%d04' % settings.BASE_NOMODULE_ID: (
+        'The maintainers key in the manifest file must be a list of strings',
+        'manifest-maintainers-list',
+        settings.DESC_DFLT
+    ),
     'C%d01' % settings.BASE_NOMODULE_ID: (
         'One of the following authors must be present in manifest: %s',
         'manifest-required-author',
@@ -632,7 +637,8 @@ class NoModuleChecker(misc.PylintOdooChecker):
         'license-allowed', 'manifest-author-string', 'manifest-deprecated-key',
         'manifest-required-author', 'manifest-required-key',
         'manifest-version-format', 'resource-not-exist',
-        'website-manifest-key-not-valid-uri', 'development-status-allowed')
+        'website-manifest-key-not-valid-uri', 'development-status-allowed',
+        'manifest-maintainers-list')
     def visit_dict(self, node):
         if not os.path.basename(self.linter.current_file) in \
                 settings.MANIFEST_FILES \
@@ -715,6 +721,13 @@ class NoModuleChecker(misc.PylintOdooChecker):
                 dev_status not in self.config.development_status_allowed):
             self.add_message('development-status-allowed',
                              node=node, args=(dev_status,))
+
+        # Check maintainers key is a list of strings
+        maintainers = manifest_dict.get('maintainers')
+        if(maintainers and (not isinstance(maintainers, list)
+                            or any(not isinstance(item, str) for item in maintainers))):
+            self.add_message('manifest-maintainers-list',
+                             node=node)
 
     @utils.check_messages('api-one-multi-together',
                           'copy-wo-api-one', 'api-one-deprecated',

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -73,6 +73,7 @@ EXPECTED_ERRORS = {
     'resource-not-exist': 3,
     'website-manifest-key-not-valid-uri': 1,
     'character-not-valid-in-resource-link': 2,
+    'manifest-maintainers-list': 1,
 }
 
 if six.PY3:

--- a/pylint_odoo/test_repo/broken_module3/__openerp__.py
+++ b/pylint_odoo/test_repo/broken_module3/__openerp__.py
@@ -3,6 +3,7 @@
     'name': 'Broken module 3 for tests',
     'license': 'AGPL-3',
     'author': ['Other', 'Odoo Community Association (OCA)'],  # expected string
+    'maintainers': 'Others, Many people',  # expected a list of strings
     'website': 'htt://odoo-community.com',
     'version': '8.0.1.0.0foo',
     'depends': ['base'],


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Maintainers key in manifest must be a list of strings, according to https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/oca_module_lifecycle_maintainer_role.rst.

Current behavior before PR: Maintainers key is not check

Desired behavior after PR is merged: Maintainers check working and validating if it is a list of strings.

Fix #200 

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
