### PR TITLE
[FIX] pylint-odoo: modify dangerous-view-replace-wo-priority to check all child tags with replace

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -822,7 +822,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
             return None
         replaces = \
             arch.xpath(".//field[@name='name' and @position='replace'][1]") + \
-            arch.xpath(".//xpath[@position='replace'][1]")
+            arch.xpath(".//*[@position='replace'][1]")
         return bool(replaces)
 
     def _check_dangerous_view_replace_wo_priority(self):

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -22,7 +22,7 @@ EXPECTED_ERRORS = {
     'copy-wo-api-one': 2,
     'create-user-wo-reset-password': 1,
     'dangerous-filter-wo-user': 1,
-    'dangerous-view-replace-wo-priority': 5,
+    'dangerous-view-replace-wo-priority': 6,
     'deprecated-openerp-xml-node': 5,
     'development-status-allowed': 1,
     'duplicate-id-csv': 2,

--- a/pylint_odoo/test_repo/broken_module/model_view2.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view2.xml
@@ -104,6 +104,29 @@
             <field name="name">view.model.form80</field>
             <field name="model">test.model</field>
         </record>
-
+        <!-- Replace with low priority wo field -->
+        <record id="view_model_form90" model="ir.ui.view">
+            <field name="name">view.model.form90</field>
+            <field name="model">test.model</field>
+            <field name="priority">10</field>
+            <field name="arch" type="xml">
+                 <label for="name" position="replace"/>
+            </field>
+        </record>
+        <!-- Record with position after and before positions -->
+        <record id="view_model_form100" model="ir.ui.view">
+            <field name="name">view.model.form100</field>
+            <field name="model">test.model</field>
+            <field name="priority">10</field>
+            <field name="arch" type="xml">
+                <label for="name" position="after"/>
+                <field name="description" position="before">
+                    <field name="name" position="move"/>
+                </field>
+                <field name="description" position="attributes">
+                    <attribute name="colors" translation="off">red</attribute>
+                </field>
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Consider next case: 
```
<record id="crm_case_form_view_leads_form_inherit" model="ir.ui.view">
    <field name="name">crm.lead.form.lead</field>
    <field name="model">crm.lead</field>
    <field name="inherit_id" ref="crm.crm_case_form_view_leads"/>
    <field name="arch" type="xml">
        <label for="contact_name" position="replace"/>
        ...
    </field>
</record>
```

Part of code where replace is use is a label tag and pylint-odoo does not recognize it, however, Odoo convert this part of code in a xpath tag with replace attribute but in that point already passed lint.

Current behavior before PR: warnings of code like above not found.

Desired behavior after PR is merged: warnings of code like above found.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
