### PR TITLE
[ADD] test-folder-imported: check if tests folder is imported in init file

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -74,12 +74,13 @@ EXPECTED_ERRORS = {
     'website-manifest-key-not-valid-uri': 1,
     'character-not-valid-in-resource-link': 2,
     'manifest-maintainers-list': 1,
+    'test-folder-imported': 2,
 }
 
 if six.PY3:
     EXPECTED_ERRORS['unnecessary-utf8-coding-comment'] = 19
 else:
-    EXPECTED_ERRORS['no-utf8-coding-comment'] = 6
+    EXPECTED_ERRORS['no-utf8-coding-comment'] = 7
 
 
 @contextmanager

--- a/pylint_odoo/test_repo/broken_module/__init__.py
+++ b/pylint_odoo/test_repo/broken_module/__init__.py
@@ -2,3 +2,4 @@
 
 from . import models
 from .models import broken_model
+from .tests import test_model

--- a/pylint_odoo/test_repo/broken_module/tests/__init__.py
+++ b/pylint_odoo/test_repo/broken_module/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_model

--- a/pylint_odoo/test_repo/broken_module/tests/test_model.py
+++ b/pylint_odoo/test_repo/broken_module/tests/test_model.py
@@ -1,0 +1,9 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestModel(TransactionCase):
+    def setUp(self):
+        super(TestModel, self).setUp()
+
+    def method1(self, example_var):
+        return example_var

--- a/pylint_odoo/test_repo/eleven_module/__init__.py
+++ b/pylint_odoo/test_repo/eleven_module/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import utf8_models
+from .tests import test_model1


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

 Currently, the `__init__.py` file in the root directory of an Odoo module may import the tests folder, e.g. https://github.com/OCA/server-tools/blob/cca5dffd0dec68e1aa4209a8747d4381a97efa89/ir_sequence_standard_default/__init__.py#L6

Current behavior before PR: 

Folder test imported in Odoo module does not check.

Desired behavior after PR is merged:

Folder test imported in Odoo module is check.

Fix #293 

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
