### PR TITLE
[FIX] add compatibility to v14.0

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -24,7 +24,7 @@ except ImportError:
 
 DFTL_VALID_ODOO_VERSIONS = [
     '4.2', '5.0', '6.0', '6.1', '7.0', '8.0', '9.0', '10.0', '11.0', '12.0',
-    '13.0',
+    '13.0', '14.0',
 ]
 DFTL_MANIFEST_VERSION_FORMAT = r"({valid_odoo_versions})\.\d+\.\d+\.\d+$"
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add compatibility to Odoo v14.0.

Current behavior before PR:
Pylint-odoo does not compatible with v14.0. 

Desired behavior after PR is merged:
Pylint-odoo compatible with v14.0. 

Fix #311 

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
