### PR TITLE
[FIX] requirements: update min version pylint and isort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
 
 install:
     # Remove packages installed from addons-apt-packages of travis file
+    - pip install -U pip
     - sed -i '/node/d' ${TRAVIS_BUILD_DIR}/install.sh
     - sed -i '/pip install ./d' ${TRAVIS_BUILD_DIR}/install.sh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 docutils==0.16
-isort==4.3.4
 lxml>=4.2.3
 polib==1.1.0
 Pygments==2.2 ;python_version < '3'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

pip 20.3 introduced a new dependency resolver that disallows having conflicting dependencies in the same environment. https://pip.pypa.io/en/stable/user_guide/?highlight=resolver#changes-to-the-pip-dependency-resolver-in-20-3-2020

As pylint-odoo requires pylint==2.5.3 (for python 3), a dependency conflict is easily obtained when trying to install it along with pylint:

conflict caused by:
        The user requested isort==4.3.21
        pylint 2.6.0 depends on isort<6 and >=4.2.5
        pylint-odoo 3.5.0 depends on isort==4.3.4

and

        The user requested pylint 2.6.0
        pylint-odoo 3.5.0 depends on pylint==2.5.3

This forces the use of an older pylint and isort version, which is not ideal.

Current behavior before PR:
All checks working correct way.

Desired behavior after PR is merged:
All checks working correct way without problems with dependencies.

Fix #306 

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr