### PR TITLE
[ADD] license_allowed: add 'OPL-1' in license allowed

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -246,7 +246,7 @@ DFTL_LICENSE_ALLOWED = [
     'AGPL-3', 'GPL-2', 'GPL-2 or any later version',
     'GPL-3', 'GPL-3 or any later version', 'LGPL-3',
     'Other OSI approved licence', 'Other proprietary',
-    'OEEL-1',
+    'OEEL-1', 'OPL-1',
 ]
 DFTL_DEVELOPMENT_STATUS_ALLOWED = [
     'Alpha', 'Beta', 'Production/Stable', 'Mature',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When trying to publish the apps in the odoo store, it sends us the following error:

Module not installable: Please change the license of your module from OEEL-1 to OPL-1
https://git.vauxoo.com/vauxoo/apps/uploads/6a0376c1d56b6a06fbb081c78f0f2149/image.png

But when using this license in the modules: the lints send the following error:
License "OPL-1" not allowed in manifest file.

Current behavior before PR:
pylint-odoo check license-allowed lint when use "OPL-1".

Desired behavior after PR is merged:
pylint-odoo does not check license-allowed for "OPL-1".

Fix https://github.com/Vauxoo/pylint-conf/issues/66

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
