### PR TITLE
[REF] requirements: upgrade pylint version

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -5,7 +5,6 @@ import os
 import re
 
 import astroid
-import isort
 import polib
 from collections import defaultdict
 from pylint.checkers import utils
@@ -429,8 +428,8 @@ class ModuleChecker(misc.WrapperModuleChecker):
         if self._is_module_name_in_whitelist(module_name):
             # ignore whitelisted modules
             return
-        isort_obj = isort.SortImports(file_contents='')
-        import_category = isort_obj.place_module(module_name)
+        isort_driver = misc.IsortDriver()
+        import_category = isort_driver.place_module(module_name)
         if import_category not in ('FIRSTPARTY', 'THIRDPARTY'):
             # skip if is not a external library or is a white list library
             return

--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -22,6 +22,15 @@ try:
 except ImportError:
     from whichcraft import which
 
+try:
+    import isort.api
+
+    HAS_ISORT_5 = True
+except ImportError:  # isort < 5
+    import isort
+
+    HAS_ISORT_5 = False
+
 DFTL_VALID_ODOO_VERSIONS = [
     '4.2', '5.0', '6.0', '6.1', '7.0', '8.0', '9.0', '10.0', '11.0', '12.0',
     '13.0', '14.0',
@@ -660,3 +669,23 @@ class WrapperModuleChecker(PylintOdooChecker):
             # with the args and kwargs of the original string
             # so it is a real error
             raise StringParseError(repr(exc))
+
+
+class IsortDriver:
+    """
+    A wrapper around isort API that changed between versions 4 and 5.
+    Taken of https://git.io/Jt3dw
+    """
+
+    def __init__(self):
+        if HAS_ISORT_5:
+            self.isort5_config = isort.api.Config()
+        else:
+            self.isort4_obj = isort.SortImports(  # pylint: disable=no-member
+                file_contents=""
+            )
+
+    def place_module(self, package):
+        if HAS_ISORT_5:
+            return isort.api.place_module(package, self.isort5_config)
+        return self.isort4_obj.place_module(package)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 docutils==0.16
+isort==4.3.21
 lxml>=4.2.3
 polib==1.1.0
 Pygments==2.2 ;python_version < '3'
 Pygments==2.6.1 ;python_version >= '3'
 pylint-plugin-utils==0.6
 pylint==1.9.5 ;python_version < '3'
-pylint==2.5.3 ;python_version >= '3'
+pylint==2.6.0 ;python_version >= '3'
 restructuredtext_lint==1.3.1
 rfc3986
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 docutils==0.16
-isort==4.3.21
 lxml>=4.2.3
 polib==1.1.0
 Pygments==2.2 ;python_version < '3'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The following line of code:

- https://github.com/OCA/pylint-odoo/blob/1b9018e3884fceced0a06a1a19b29ffaffa5f701/requirements.txt#L8

is pinning the pylint version because it could raise red with newer versions but we need keep upgrading this version each period of time

There is a new release pylint-2.6.0 on Aug 21, 2020

Current behavior before PR:
pylint-odoo works correctly.

Desired behavior after PR is merged:
pylint-odoo works correctly with new pylint version.

Fix #319 

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
