### PR TITLE
Add .pylintrc example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,9 +157,9 @@ Usage
 
 ``pylint --load-plugins=pylint_odoo -e odoolint path/to/test``
 
-or use configuration file (find example configuration in https://github.com/oca/pylint-odoo/blob/patch-1/pylint_odoo/examples/.pylintrc):
+or use configuration file (find example configuration in https://github.com/OCA/pylint-odoo/tree/master/pylint_odoo/examples/.pylintrc):
 
-``pylint --rcfile=.pylintrc -e odoolint path/to/test``
+``pylint --rcfile=.pylintrc path/to/test``
 
 Example to test just odoo-lint case:
 

--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,11 @@ Or
 Usage
 -----
 
-``pylint --load-plugins=pylint_odoo -e odoolint ...``
+``pylint --load-plugins=pylint_odoo -e odoolint path/to/test``
+
+or use configuration file (find example configuration in https://github.com/oca/pylint-odoo/blob/patch-1/pylint_odoo/examples/.pylintrc):
+
+``pylint --rcfile=.pylintrc -e odoolint path/to/test``
 
 Example to test just odoo-lint case:
 

--- a/pylint_odoo/examples/.pylintrc
+++ b/pylint_odoo/examples/.pylintrc
@@ -1,0 +1,82 @@
+[MASTER]
+load-plugins=pylint_odoo
+score=n
+
+[ODOOLINT]
+readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
+manifest_required_authors=Odoo Community Association (OCA)
+manifest_required_keys=license
+manifest_deprecated_keys=description,active
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+valid_odoo_versions=13.0
+
+[MESSAGES CONTROL]
+disable=all
+
+
+enable=anomalous-backslash-in-string,
+    api-one-deprecated,
+    api-one-multi-together,
+    assignment-from-none,
+    attribute-deprecated,
+    class-camelcase,
+    dangerous-default-value,
+    dangerous-view-replace-wo-priority,
+    development-status-allowed,
+    duplicate-id-csv,
+    duplicate-key,
+    duplicate-xml-fields,
+    duplicate-xml-record-id,
+    eval-referenced,
+    eval-used,
+    incoherent-interpreter-exec-perm,
+    license-allowed,
+    manifest-author-string,
+    manifest-deprecated-key,
+    manifest-required-author,
+    manifest-required-key,
+    manifest-version-format,
+    method-compute,
+    method-inverse,
+    method-required-super,
+    method-search,
+    missing-import-error,
+    missing-manifest-dependency,
+    openerp-exception-warning,
+    pointless-statement,
+    pointless-string-statement,
+    print-used,
+    redundant-keyword-arg,
+    redundant-modulename-xml,
+    reimported,
+    relative-import,
+    return-in-init,
+    rst-syntax-error,
+    sql-injection,
+    too-few-format-args,
+    translation-field,
+    translation-required,
+    unreachable,
+    use-vim-comment,
+    wrong-tabs-instead-of-spaces,
+    xml-syntax-error,
+    # messages that do not cause the lint step to fail
+    consider-merging-classes-inherited,
+    create-user-wo-reset-password,
+    dangerous-filter-wo-user,
+    deprecated-module,
+    file-not-used,
+    invalid-commit,
+    missing-newline-extrafiles,
+    missing-readme,
+    no-utf8-coding-comment,
+    odoo-addons-relative-import,
+    old-api7-method-defined,
+    redefined-builtin,
+    too-complex,
+    unnecessary-utf8-coding-comment
+
+[REPORTS]
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+output-format=colorized
+reports=no


### PR DESCRIPTION
Pylint-odoo shoud come with example .pylintrc file one can copy to project and start using right away.

This file is taken from https://github.com/OCA/server-env/blob/13.0/.pylintrc