### PR TITLE
[FIX] Add pbr to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 docutils==0.16
 lxml>=4.2.3
+pbr
 polib==1.1.0
 Pygments==2.2 ;python_version < '3'
 Pygments==2.6.1 ;python_version >= '3'


### PR DESCRIPTION
The library is needed for the setup, but it is not specified in requirements.
Its installation depends on setuptools' `easy_install`, which is unreliable: 
- https://docs.openstack.org/pbr/latest/#pbr-python-build-reasonableness 
- https://pip.pypa.io/en/latest/cli/pip_install/#controlling-setup-requires

Example of the error that might be caused: https://github.com/Tecnativa/doodba/runs/2314862208?check_suite_focus=true#step:7:1476
Pre-installing `pbr` with pip solves the issue, so it could be added to the `requirements.txt` to force the installation that way.

ping @Yajo 