### PR TITLE
[FIX] attribute-string-redundant: "string" of related field is taken from the referenced one

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -515,10 +515,11 @@ class NoModuleChecker(misc.PylintOdooChecker):
                     isinstance(node.parent.targets[0], astroid.AssignName)):
                 field_name = (node.parent.targets[0].name
                               .replace('_', ' '))
+            is_related = bool([1 for kw in node.keywords or [] if kw.arg == 'related'])
             for argument in args:
                 argument_aux = argument
                 # Check this 'name = fields.Char("name")'
-                if (isinstance(argument, astroid.Const) and
+                if (not is_related and isinstance(argument, astroid.Const) and
                     (index ==
                      FIELDS_METHOD.get(argument.parent.func.attrname, 0)) and
                     (argument.value in
@@ -536,7 +537,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
                                          node=argument_aux)
                     # Check if the param string is equal to the name
                     #   of variable
-                    elif argument.arg == 'string' and \
+                    elif not is_related and argument.arg == 'string' and \
                         (isinstance(argument_aux, astroid.Const) and
                          argument_aux.value in
                          [field_name.capitalize(), field_name.title()]):

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -54,6 +54,9 @@ class TestModel(models.Model):
         'Other Field2',
         copy=True,
     )
+    field_related = fields.Char('Field Related', related='model_id.related_field')
+    other_field_related = fields.Char(
+        related='model_id.related_field', string='Other Field Related')
 
     # This is a inherit overwrite field then don't should show errors related
     # with creation of fields.


### PR DESCRIPTION
So redefining the string is a valid case.
For instance:
 - parent_date = fields.Date(related="parent_id.date", string="parent date")

If a string is not specified, field will be "Date".
But I need the string to be "Parent Date"

Fix https://github.com/OCA/pylint-odoo/issues/332