### PR TITLE
[FIX] attribute-deprecated: Check only 'Model' class' attributes

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -840,7 +840,9 @@ class NoModuleChecker(misc.PylintOdooChecker):
     @utils.check_messages('attribute-deprecated')
     def visit_assign(self, node):
         node_left = node.targets[0]
-        if isinstance(node_left, astroid.AssignName):
+        if (isinstance(node.parent, astroid.ClassDef) and
+                isinstance(node_left, astroid.AssignName) and
+                [1 for m in node.parent.basenames if 'Model' in m]):
             if node_left.name in self.config.attribute_deprecated:
                 self.add_message('attribute-deprecated',
                                  node=node_left, args=(node_left.name,))

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -477,3 +477,11 @@ class TestModel(models.Model):
             "CREATE VIEW %s AS (SELECT * FROM res_partner)" % _variable)
         self._cr.execute(
             "CREATE VIEW %s AS (SELECT * FROM res_partner)" % variable)
+
+    def func(a):
+        length = len(a)
+        return length
+
+
+class NoOdoo(object):
+    length = 0


### PR DESCRIPTION
Fix https://github.com/OCA/pylint-odoo/issues/339

cc @voronind