### PR TITLE
[FIX] sql-injection: Fix false positives

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -518,20 +518,9 @@ class NoModuleChecker(misc.PylintOdooChecker):
         first_arg = node.args[0]
         is_concatenation = self._check_node_for_sqli_risk(first_arg)
         # if first parameter is a variable, check how it was built instead
-        if (not is_concatenation and
-                isinstance(first_arg, (astroid.Name, astroid.Subscript))):
-
-            # 1) look for parent scope (where the definition lives)
-            current = node
-            while (current and not isinstance(current.parent, astroid.FunctionDef)):
-                current = current.parent
-            parent = current.parent
-
-            # 2) check how was the variable built
-            for node_ofc in parent.nodes_of_class(astroid.Assign):
-                if node_ofc.targets[0].as_string() != first_arg.as_string():
-                    continue
-                is_concatenation = self._check_node_for_sqli_risk(node_ofc.value)
+        if not is_concatenation:
+            for node_assignation in self._get_assignation_nodes(first_arg):
+                is_concatenation = self._check_node_for_sqli_risk(node_assignation)
                 if is_concatenation:
                     break
         return is_concatenation

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -56,7 +56,7 @@ EXPECTED_ERRORS = {
     'print-used': 1,
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,
-    'sql-injection': 17,
+    'sql-injection': 21,
     'str-format-used': 3,
     'translation-field': 2,
     'translation-required': 15,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -56,7 +56,7 @@ EXPECTED_ERRORS = {
     'print-used': 1,
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,
-    'sql-injection': 16,
+    'sql-injection': 17,
     'str-format-used': 3,
     'translation-field': 2,
     'translation-required': 15,

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -56,7 +56,7 @@ EXPECTED_ERRORS = {
     'print-used': 1,
     'redundant-modulename-xml': 1,
     'rst-syntax-error': 2,
-    'sql-injection': 18,
+    'sql-injection': 16,
     'str-format-used': 3,
     'translation-field': 2,
     'translation-required': 15,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -411,6 +411,9 @@ class TestModel(models.Model):
                 query=sql_query,
             ))
 
+        self._cr.execute(
+            'SELECT name FROM %(table)s' % {'table': self._table})
+
     # old api
     def sql_injection_modulo_operator(self, cr, uid, ids, context=None):
         # Use of % operator: risky
@@ -432,6 +435,9 @@ class TestModel(models.Model):
         values = ([1, 2, 3, ], )
         self._cr.execute(var % values)
 
+        self._cr.execute(
+            'SELECT name FROM account WHERE id IN %(ids)s' % {'ids': ids})
+
     def sql_injection_executemany(self, ids, cr, v1, v2):
         # Check executemany() as well
         self.cr.executemany(
@@ -445,6 +451,9 @@ class TestModel(models.Model):
         var = 'SELECT name FROM account WHERE id IN {}'
         values = (1, 2, 3)
         self._cr.execute(var.format(values))
+
+        self.cr.execute(
+            'SELECT name FROM account WHERE id IN {ids}'.format(ids=ids))
 
     def sql_injection_plus_operator(self, ids, cr):
         # Use of +: risky
@@ -473,6 +482,12 @@ class TestModel(models.Model):
         self._cr.execute(var)
 
         var[1] = 'SELECT name FROM account WHERE id IN %s' % tuple(ids)
+        self._cr.execute(var[1])
+
+        var = 'SELECT name FROM account WHERE id IN %(ids)s' % {'ids': tuple(ids)}
+        self._cr.execute(var)
+
+        var[1] = 'SELECT name FROM account WHERE id IN %(ids)s' % {'ids': tuple(ids)}
         self._cr.execute(var[1])
 
     def sql_no_injection_private_attributes(self, _variable, variable):

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -442,6 +442,10 @@ class TestModel(models.Model):
         self.cr.execute(
             'SELECT name FROM account WHERE id IN {}'.format(ids))
 
+        var = 'SELECT name FROM account WHERE id IN {}'
+        values = (1, 2, 3)
+        self._cr.execute(var.format(values))
+
     def sql_injection_plus_operator(self, ids, cr):
         # Use of +: risky
         self.cr.execute(

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -424,6 +424,7 @@ class TestModel(models.Model):
             'SELECT name FROM account WHERE id IN %s' % (tuple(ids),))
 
         operator = 'WHERE'
+        # Ignore sql-injection because of there is a parameter e.g. "ids"
         self._cr.execute(
             'SELECT name FROM account %s id IN %%s' % operator, ids)
 
@@ -447,6 +448,7 @@ class TestModel(models.Model):
             'SELECT name FROM account WHERE id IN ' + str(tuple(ids)))
 
         operator = 'WHERE'
+        # Ignore sql-injection because of there is a parameter e.g. "ids"
         self._cr.execute(
             'SELECT name FROM account ' + operator + ' id IN %s', ids)
         self.cr.execute(
@@ -481,7 +483,24 @@ class TestModel(models.Model):
         self._cr.execute(
             "CREATE VIEW %s AS (SELECT * FROM res_partner)" % variable)
 
-    def func(a):
+    def sql_no_injection_private_methods(self):
+        # Skip sql-injection using private methods
+        self.env.cr.execute(
+            """
+            CREATE OR REPLACE VIEW %s AS (
+                %s %s %s %s
+            )
+        """
+            % (
+                self._table,
+                self._select(),
+                self._from(),
+                self._where(),
+                self._group_by(),
+            )
+        )
+
+    def func(self, a):
         length = len(a)
         return length
 


### PR DESCRIPTION
Ignore cases when you are using almost one parameter
It means you maybe are using a concatenation for valid concatenation but parameters for other cases

Ignore cases for private parameters and private methods too
It is a common way to use a valid "cr.execute" for Odoo views in newer
versions

Fix https://github.com/OCA/pylint-odoo/issues/334

It could depends of feedback from:
 - https://github.com/odoo/odoo/pull/76185