### PR TITLE
[FIX] pylint_odoo: Fix manifest_version_format option ignored

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -117,9 +117,10 @@ class PylintOdooChecker(BaseChecker):
             'valid_odoo_versions'].config.valid_odoo_versions
         valid_odoo_versions = '|'.join(
             map(re.escape, valid_odoo_versions))
+        manifest_version_format = self.linter._all_options[
+            'manifest_version_format'].config.manifest_version_format
         self.config.manifest_version_format_parsed = (
-            DFTL_MANIFEST_VERSION_FORMAT.format(
-                valid_odoo_versions=valid_odoo_versions))
+            manifest_version_format.format(valid_odoo_versions=valid_odoo_versions))
         return re.match(self.config.manifest_version_format_parsed, string)
 
     def get_manifest_file(self, node):

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -254,6 +254,31 @@ class MainTest(unittest.TestCase):
         self.expected_errors.pop('javascript-lint')
         self.assertEqual(self.expected_errors, real_errors)
 
+    def test_85_valid_odoo_version_format(self):
+        """Test --manifest_version_format parameter"""
+        # First, run Pylint for version 8.0
+        extra_params = [
+            '--manifest_version_format="8\.0\.\d+\.\d+.\d+$"'
+            '--valid_odoo_versions=""',
+            '--disable=all',
+            '--enable=manifest-version-format',
+        ]
+        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        real_errors = pylint_res.linter.stats['by_msg']
+        expected_errors = {
+            'manifest-version-format': 6,
+        }
+        self.assertDictEqual(real_errors, expected_errors)
+
+        # Now for version 11.0
+        extra_params[0] = '--manifest_version_format="11\.0\.\d+\.\d+.\d+$"'
+        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        real_errors = pylint_res.linter.stats['by_msg']
+        expected_errors = {
+            'manifest-version-format': 5,
+        }
+        self.assertDictEqual(real_errors, expected_errors)
+
     def test_90_valid_odoo_versions(self):
         """Test --valid_odoo_versions parameter when it's '8.0' & '11.0'"""
         # First, run Pylint for version 8.0


### PR DESCRIPTION
Fix https://github.com/OCA/pylint-odoo/issues/337