### PR TITLE
[REF] invalid-name, unused-argument: Suppress check for migrations path

### DIFF
--- a/pylint_odoo/augmentations/main.py
+++ b/pylint_odoo/augmentations/main.py
@@ -1,9 +1,12 @@
 
 import os
 
-from pylint_plugin_utils import suppress_message
-from pylint.checkers.base import BasicChecker
+from astroid import FunctionDef, Module
+from pylint.checkers.base import BasicChecker, NameChecker
 from pylint.checkers.imports import ImportsChecker
+from pylint.checkers.variables import VariablesChecker
+from pylint_plugin_utils import suppress_message
+
 from .. import settings
 
 
@@ -32,6 +35,35 @@ def is_valid_openerp_osv_deprecated(node):
     return False
 
 
+def is_migration_path(node):
+    """module/x.y.z/migrations/pre-migration.py path has a few false negatives
+
+    Considering that standard method is:
+        def migrate(cr, version):
+
+    - invalid-name (C0103) for module and argument name
+    e.g. "pre-migration.py" instead of pre_migration.py
+    e.g. "cr" for cursor
+
+    - unused-argument (W0613) for argument
+    e.g. "version" for version of Odoo
+
+    node: can be module or functiondef
+    """
+
+    # get 'migrations' from 'module/migrations/x.y.z/pre-migration.py'
+    if os.path.basename(os.path.dirname(os.path.dirname(
+            node.root().file))) != 'migrations':
+        return False
+
+    # pre-migration.py
+    if (isinstance(node, Module) and '-' in node.name or
+            # def migrate(cr, version):
+            isinstance(node, FunctionDef) and node.name == 'migrate'):
+        return True
+    return False
+
+
 def apply_augmentations(linter):
     """Apply suppression rules."""
 
@@ -47,3 +79,9 @@ def apply_augmentations(linter):
     discard = hasattr(ImportsChecker, 'visit_from') and \
         ImportsChecker.visit_from or ImportsChecker.visit_importfrom
     suppress_message(linter, discard, 'W0402', is_valid_openerp_osv_deprecated)
+
+    # C0103 - invalid-name and W0613 - unused-argument for migrations/
+    suppress_message(linter, NameChecker.visit_module, 'C0103', is_migration_path)
+    suppress_message(linter, NameChecker.visit_functiondef, 'C0103', is_migration_path)
+    suppress_message(linter, VariablesChecker.leave_functiondef, 'W0613',
+                     is_migration_path)

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -383,6 +383,35 @@ class MainTest(unittest.TestCase):
             {"po-msgstr-variables": 1, "missing-readme": 1}
         )
 
+    def test_140_check_suppress_migrations(self):
+        """Test migrations path supress checks"""
+        extra_params = [
+            '--disable=all',
+            '--enable=invalid-name,unused-argument',
+        ]
+        path_modules = [os.path.join(
+            os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+            'test_repo', 'test_module', 'migrations', '10.0.1.0.0', 'pre-migration.py')]
+
+        # Messages suppressed with plugin for migration
+        pylint_res = self.run_pylint(path_modules, extra_params)
+        real_errors = pylint_res.linter.stats['by_msg']
+        expected_errors = {
+            'invalid-name': 1,
+            'unused-argument': 1,
+        }
+        self.assertDictEqual(real_errors, expected_errors)
+
+        # Messages raised without plugin
+        self.default_options.remove('--load-plugins=pylint_odoo')
+        pylint_res = self.run_pylint(path_modules, extra_params)
+        real_errors = pylint_res.linter.stats['by_msg']
+        expected_errors = {
+            'invalid-name': 3,
+            'unused-argument': 2,
+        }
+        self.assertDictEqual(real_errors, expected_errors)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylint_odoo/test_repo/test_module/migrations/10.0.1.0.0/pre-migration.py
+++ b/pylint_odoo/test_repo/test_module/migrations/10.0.1.0.0/pre-migration.py
@@ -1,0 +1,13 @@
+from odoo import SUPERUSER_ID, api
+
+
+def method(cr, unused):
+    # invalid-name cr and unused-argument unused
+    return cr
+
+
+def migrate(cr, version):
+    # suppressed invalid-name cr and unused-argument version
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        env.ref('xmlid').unlink()


### PR DESCRIPTION
The following path:
 - module/x.y.z/migrations/pre-migration.py
has a few false negatives

Considering that standard method is:
    def migrate(cr, version):

- invalid-name (C0103) for module and argument name
  - e.g. "pre-migration.py" instead of pre_migration.py
  - e.g. "cr" for cursor

- unused-argument (W0613) for argument
  - e.g. "version" for version of Odoo

They are valid since that Odoo has already defined as it

So supressing from augmentations

Fix https://github.com/OCA/pylint-odoo/issues/338
