### PR TITLE
[REF] requirements: Upgrade pylint version

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -11,7 +11,23 @@ from lxml import etree
 from pylint.checkers import BaseChecker, BaseTokenChecker
 from pylint.interfaces import UNDEFINED
 from pylint.interfaces import IAstroidChecker, ITokenChecker
-from pylint.utils import _basename_in_blacklist_re
+try:
+    # sha 5805a73 pylint 2.9
+    from pylint.lint.expand_modules import _is_in_ignore_list_re
+except ImportError:
+    try:
+        # sha 63ca0597 pylint 2.8
+        from pylint.lint.expand_modules import (
+            _basename_in_ignore_list_re as _is_in_ignore_list_re)
+    except ImportError:
+        try:
+            # sha d19c77337 pylint 2.7
+            from pylint.utils.utils import (
+                _basename_in_ignore_list_re as _is_in_ignore_list_re)
+        except ImportError:
+            # Compatibility with pylint<=2.6.0
+            from pylint.utils import (
+                _basename_in_blacklist_re as _is_in_ignore_list_re)
 from restructuredtext_lint import lint_file as rst_lint
 from six import string_types
 
@@ -156,8 +172,7 @@ class PylintOdooChecker(BaseChecker):
                 fext = os.path.splitext(filename)[1].lower()
                 fname = os.path.join(root, filename)
                 # If the file is within black_list_re is ignored
-                if _basename_in_blacklist_re(fname,
-                                             self.linter.config.black_list_re):
+                if _is_in_ignore_list_re(fname, self.linter.config.black_list_re):
                     continue
                 # If the file is within ignores is ignored
                 find = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-docutils==0.16
+docutils<=0.17.1
 lxml>=4.2.3
 pbr
-polib==1.1.0
+polib<=1.1.1
 Pygments==2.2 ;python_version < '3'
-Pygments==2.6.1 ;python_version >= '3'
+Pygments<=2.10.0 ;python_version >= '3'
 pylint-plugin-utils==0.6
 pylint==1.9.5 ;python_version < '3'
-pylint==2.6.0 ;python_version >= '3'
-restructuredtext_lint==1.3.1
+pylint<=2.10.2 ;python_version >= '3'
+restructuredtext_lint<=1.3.2
 rfc3986
 six
 whichcraft


### PR DESCRIPTION
Add compatibility for pylint between 2.6 and 2.9

The method `_is_in_ignore_list_re` changed for each version