### PR TITLE
[FIX] sql-injection: AttributeError: 'NoneType' object has no attribute 'parent'

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -537,12 +537,12 @@ class NoModuleChecker(misc.PylintOdooChecker):
             current = node
             while (current and not isinstance(current.parent, astroid.FunctionDef)):
                 current = current.parent
-            parent = current.parent
-
-            # 2) check how was the variable built
-            for assign_node in parent.nodes_of_class(astroid.Assign):
-                if assign_node.targets[0].as_string() == node.as_string():
-                    yield assign_node.value
+            if current:
+                parent = current.parent
+                # 2) check how was the variable built
+                for assign_node in parent.nodes_of_class(astroid.Assign):
+                    if assign_node.targets[0].as_string() == node.as_string():
+                        yield assign_node.value
 
     @utils.check_messages("print-used")
     def visit_print(self, node):

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -534,3 +534,13 @@ class TestModel(models.Model):
 
 class NoOdoo(object):
     length = 0
+
+
+if __name__ == '__main__':
+    self = None
+    queries = [
+        "SELECT id FROM res_partner",
+        "SELECT id FROM res_users",
+    ]
+    for query in queries:
+        self.env.cr.execute(query)


### PR DESCRIPTION
Using the following code:

    queries = [
        "SELECT id FROM res_partner",
        "SELECT id FROM res_users",
    ]
    for query in queries:
        self.env.cr.execute(query)

The check sql-injection shows the following error:
 - AttributeError: 'NoneType' object has no attribute 'parent'

So, Now it is validating if it is not None