### PR TITLE
[FIX] sql-injection: No sql-injection using constants and small fixes

### DIFF
--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -527,6 +527,12 @@ class TestModel(models.Model):
             )
         )
 
+    def sql_no_injection_constants(self):
+        self.env.cr.execute("SELECT * FROM %s" % 'table_constant')
+        self.env.cr.execute("SELECT * FROM {}".format('table_constant'))
+        self.env.cr.execute(
+            "SELECT * FROM %(table_variable)s" % {'table_variable': 'table_constant'})
+
     def func(self, a):
         length = len(a)
         return length


### PR DESCRIPTION
* [REF] sql-injection: No sql-injection using constants

The following examples should not be considered as sql-injection:

    self.env.cr.execute("SELECT * FROM %s" % 'table_constant')
    self.env.cr.execute("SELECT * FROM {}".format('table_constant'))
    self.env.cr.execute("SELECT * FROM %(table_variable)s" % {'table_variable': 'table_constant'})

Since that the constant is not possible to inject

* [FIX] sql-injection: AttributeError: 'NoneType' object has no attribute 'parent'

Using the following code:

    queries = [
        "SELECT id FROM res_partner",
        "SELECT id FROM res_users",
    ]
    for query in queries:
        self.env.cr.execute(query)

The check sql-injection shows the following error:
- AttributeError: 'NoneType' object has no attribute 'parent'

So, Now it is validating if it is not None

* [FIX] sql-injection: Fix false positive using BinOp "+"

Considering the following valid case:

    cr.execute('SELECT ' + operator + ' FROM table' + 'WHERE')

The representation tree is:

    node.repr_tree()
    BinOp(
    op='+',
    left=BinOp(
        op='+',
        left=BinOp(
            op='+',
            left=Const(value='SELECT '),
            right=Name(name='operator')),
        right=Const(value=' FROM table')),
    right=Const(value='WHERE'))

Notice that left node is another BinOp node
So, it need to be considered recursively
