### PR TITLE
[REVERT] requirements: Using pylint<2.11.0 because issue 5096

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Pygments==2.2 ;python_version < '3'
 Pygments<=2.10.0 ;python_version >= '3'
 pylint-plugin-utils==0.6
 pylint==1.9.5 ;python_version < '3'
-pylint<=2.11.1 ;python_version >= '3'
+pylint<2.11.0 ;python_version >= '3'
 restructuredtext_lint<=1.3.2
 rfc3986
 six


### PR DESCRIPTION
Update pylint version after fixing the following issue:
 - https://github.com/PyCQA/pylint/issues/5096