### PR TITLE
[FIX] OdooChecker: Discard migrations folder as odoo main module

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -230,7 +230,7 @@ class PylintOdooChecker(BaseChecker):
             self.manifest_dict = {}
             self.manifest_file = None
         self.is_main_odoo_module = False
-        if self.manifest_file and (
+        if self.manifest_file and os.path.basename(node.file) == '__init__.py' and (
                 node.name.count('.') == 0 or
                 node.name.endswith(self.odoo_module_name_with_ns)
         ):

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -414,6 +414,24 @@ class MainTest(unittest.TestCase):
         }
         self.assertDictEqual(real_errors, expected_errors)
 
+    def test_140_check_migrations_is_not_odoo_module(self):
+        """Checking that migrations folder is not considered a odoo module
+        Related to https://github.com/OCA/pylint-odoo/issues/357"""
+        extra_params = [
+            '--disable=all',
+            '--enable=missing-readme',
+        ]
+        test_module = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+            'test_repo', 'test_module')
+        path_modules = [
+            os.path.join(test_module, '__init__.py'),
+            os.path.join(test_module, 'migrations', '10.0.1.0.0', 'pre-migration.py')]
+        pylint_res = self.run_pylint(path_modules, extra_params)
+        real_errors = pylint_res.linter.stats['by_msg']
+        expected_errors = {}
+        self.assertDictEqual(real_errors, expected_errors)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
pre-commit script is running file by file as:

 - `pylint module/__init__.py module/migrations/pre-commit.py`

It is generating a corner-case where odoo manifest file variable is filled

and pre-commit is the main module and it was detecting as main odoo module

But it is not

Validating the name of node.file is `__init__.py`
we can be sure that it is related with the odoo main module

Fix https://github.com/OCA/pylint-odoo/issues/357