### PR TITLE
[FIX] Pinned lazy-object-proxy for Python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+lazy-object-proxy==1.6 ;python_version < '3'
 docutils<=0.17.1
 lxml>=4.2.3
 pbr


### PR DESCRIPTION
Travis builds on Python 2.7 break because `lazy-object-proxy` can't be installed. This should fix it.