### PR TITLE
[REF] requirements: Bump pylint package from 2.11.1 to 2.13.5 for py3.x

### DIFF
--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -144,6 +144,11 @@ class MainTest(unittest.TestCase):
                 res = Run(cmd, do_exit=False)  # pylint2
             except TypeError:
                 res = Run(cmd, exit=False)  # pylint1
+        if not hasattr(res.linter.stats, 'by_msg'):
+            # pylint<2.12 compatibility
+            class stats(object):
+                by_msg = res.linter.stats['by_msg']
+            setattr(res.linter, 'stats', stats)
         return res
 
     def test_10_path_dont_exist(self):
@@ -157,7 +162,7 @@ class MainTest(unittest.TestCase):
     def test_20_expected_errors(self):
         """Expected vs found errors"""
         pylint_res = self.run_pylint(self.paths_modules)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.assertEqual(self.expected_errors, real_errors)
 
     def test_25_checks_without_coverage(self):
@@ -170,7 +175,7 @@ class MainTest(unittest.TestCase):
         }
         extra_params = ['--valid_odoo_versions=8.0']
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        msgs_found = pylint_res.linter.stats['by_msg'].keys()
+        msgs_found = pylint_res.linter.stats.by_msg.keys()
         plugin_msgs = set(misc.get_plugin_msgs(pylint_res)) - excluded_msgs
         test_missed_msgs = sorted(list(plugin_msgs - set(msgs_found)))
         self.assertFalse(
@@ -182,7 +187,7 @@ class MainTest(unittest.TestCase):
         """Test disabling checkers"""
         self.default_extra_params.append('--disable=dangerous-filter-wo-user')
         pylint_res = self.run_pylint(self.paths_modules)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.expected_errors.pop('dangerous-filter-wo-user')
         self.assertEqual(self.expected_errors, real_errors)
 
@@ -192,7 +197,7 @@ class MainTest(unittest.TestCase):
                         '--enable=deprecated-module',
                         '--deprecated-modules=openerp.osv']
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.assertListEqual(list(real_errors.items()),
                              list([('deprecated-module', 4)]))
 
@@ -202,7 +207,7 @@ class MainTest(unittest.TestCase):
                         '--disable=all',
                         '--enable=deprecated-openerp-xml-node']
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.assertListEqual(list(real_errors.items()),
                              list([('deprecated-openerp-xml-node', 4)]))
 
@@ -213,7 +218,7 @@ class MainTest(unittest.TestCase):
                         '--disable=all',
                         '--enable=deprecated-openerp-xml-node']
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.assertListEqual(list(real_errors.items()),
                              list([('deprecated-openerp-xml-node', 3)]))
 
@@ -232,7 +237,7 @@ class MainTest(unittest.TestCase):
         my_which("noeslint")
         pylint_res = self.run_pylint(self.paths_modules)
         misc.which = which_original
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.expected_errors.pop('javascript-lint')
         self.assertEqual(self.expected_errors, real_errors)
 
@@ -251,7 +256,7 @@ class MainTest(unittest.TestCase):
         misc.which = my_which
         pylint_res = self.run_pylint(self.paths_modules)
         misc.which = which_original
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.expected_errors.pop('javascript-lint')
         self.assertEqual(self.expected_errors, real_errors)
 
@@ -265,7 +270,7 @@ class MainTest(unittest.TestCase):
             '--enable=manifest-version-format',
         ]
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
             'manifest-version-format': 6,
         }
@@ -274,7 +279,7 @@ class MainTest(unittest.TestCase):
         # Now for version 11.0
         extra_params[0] = '--manifest_version_format="11\.0\.\d+\.\d+.\d+$"'
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
             'manifest-version-format': 5,
         }
@@ -289,7 +294,7 @@ class MainTest(unittest.TestCase):
             '--enable=xml-attribute-translatable,manifest-version-format',
         ]
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
             'manifest-version-format': 6,
             'xml-attribute-translatable': 1,
@@ -299,7 +304,7 @@ class MainTest(unittest.TestCase):
         # Now for version 11.0
         extra_params[0] = '--valid_odoo_versions=11.0'
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
             'manifest-version-format': 5,
         }
@@ -315,7 +320,7 @@ class MainTest(unittest.TestCase):
         extra_params = ['--disable=all', '--enable=no-utf8-coding-comment,'
                         'unnecessary-utf8-coding-comment']
         pylint_res = self.run_pylint(modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.assertListEqual(list(real_errors.items()),
                              list([('unnecessary-utf8-coding-comment', 2)]))
 
@@ -330,7 +335,7 @@ class MainTest(unittest.TestCase):
             '--enable=manifest-required-author',
         ]
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
             'manifest-required-author': 4,
         }
@@ -339,7 +344,7 @@ class MainTest(unittest.TestCase):
         # Then, run it using multiple authors
         extra_params[0] = '--manifest_required_authors=Vauxoo,Other'
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors['manifest-required-author'] = 3
         self.assertDictEqual(real_errors, expected_errors)
 
@@ -347,7 +352,7 @@ class MainTest(unittest.TestCase):
         extra_params[0] = ('--manifest_required_author='
                            'Odoo Community Association (OCA)')
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors_deprecated = {
             'manifest-required-author': (
                 EXPECTED_ERRORS['manifest-required-author']),
@@ -362,13 +367,13 @@ class MainTest(unittest.TestCase):
             '--enable=missing-import-error',
         ]
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors_110 = pylint_res.linter.stats['by_msg']
+        real_errors_110 = pylint_res.linter.stats.by_msg
         self.assertEqual(self.expected_errors.get('missing-import-error'),
                          real_errors_110.get('missing-import-error'))
 
         extra_params[0] = '--valid_odoo_versions=12.0'
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
-        real_errors_120 = pylint_res.linter.stats['by_msg']
+        real_errors_120 = pylint_res.linter.stats.by_msg
         self.assertFalse(real_errors_120)
 
     def test_130_odoo_namespace_repo(self):
@@ -378,7 +383,7 @@ class MainTest(unittest.TestCase):
             '--enable=po-msgstr-variables,missing-readme',
         ]
         pylint_res = self.run_pylint([self.odoo_namespace_addons_path], extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.assertDictEqual(
             real_errors,
             {"po-msgstr-variables": 1, "missing-readme": 1}
@@ -396,7 +401,7 @@ class MainTest(unittest.TestCase):
 
         # Messages suppressed with plugin for migration
         pylint_res = self.run_pylint(path_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
             'invalid-name': 1,
             'unused-argument': 1,
@@ -406,7 +411,7 @@ class MainTest(unittest.TestCase):
         # Messages raised without plugin
         self.default_options.remove('--load-plugins=pylint_odoo')
         pylint_res = self.run_pylint(path_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
             'invalid-name': 3,
             'unused-argument': 2,
@@ -427,7 +432,7 @@ class MainTest(unittest.TestCase):
             os.path.join(test_module, '__init__.py'),
             os.path.join(test_module, 'migrations', '10.0.1.0.0', 'pre-migration.py')]
         pylint_res = self.run_pylint(path_modules, extra_params)
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {}
         self.assertDictEqual(real_errors, expected_errors)
 
@@ -464,7 +469,7 @@ def fstring_no_sqli(self):
             f.flush()
             pylint_res = self.run_pylint([f.name], extra_params)
 
-        real_errors = pylint_res.linter.stats['by_msg']
+        real_errors = pylint_res.linter.stats.by_msg
         self.assertDictEqual(real_errors, {'sql-injection': 4})
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Pygments==2.2 ;python_version < '3'
 Pygments<=2.10.0 ;python_version >= '3'
 pylint-plugin-utils==0.6
 pylint==1.9.5 ;python_version < '3'
-pylint<=2.11.1 ;python_version >= '3'
+pylint<=2.13.5 ;python_version >= '3'
 restructuredtext_lint<=1.3.2
 rfc3986
 six


### PR DESCRIPTION
# Changelog 

`git diff v2.11.1..v2.13.5`

```diff
diff --git a/ChangeLog b/ChangeLog
index c730dc5b..32c5122f 100644
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,30 +2,1063 @@
 Pylint's ChangeLog
 ------------------
 
-
-
-What's New in Pylint 2.12.0?
+What's New in Pylint 2.14.0?
 ============================
 Release date: TBA
 
 ..
-  Put new features here and also in 'doc/whatsnew/2.12.rst'
+  Put new features here and also in 'doc/whatsnew/2.14.rst'
 
 
 
-What's New in Pylint 2.11.2?
+..
+  Insert your changelog randomly, it will reduce merge conflicts
+  (Ie. not necessarily at the end)
+
+
+What's New in Pylint 2.13.6?
 ============================
 Release date: TBA
 
 
 
+What's New in Pylint 2.13.5?
+============================
+Release date: 2022-04-06
+
+* Fix false positive regression in 2.13.0 for ``used-before-assignment`` for
+  homonyms between variable assignments in try/except blocks and variables in
+  subscripts in comprehensions.
+
+  Closes #6069
+  Closes #6136
+
+* ``lru-cache-decorating-method`` has been renamed to ``cache-max-size-none`` and
+  will only be emitted when ``maxsize`` is ``None``.
+
+  Closes #6180
+
+* Fix false positive for ``unused-import`` when disabling both ``used-before-assignment`` and ``undefined-variable``.
+
+  Closes #6089
+
+* Narrow the scope of the ``unnecessary-ellipsis`` checker to:
+  * functions & classes which contain both a docstring and an ellipsis.
+  * A body which contains an ellipsis ``nodes.Expr`` node & at least one other statement.
+
+* Fix false positive for ``used-before-assignment`` for assignments taking place via
+  nonlocal declarations after an earlier type annotation.
+
+  Closes #5394
+
+* Fix crash for ``redefined-slots-in-subclass`` when the type of the slot is not a const or a string.
+
+  Closes #6100
+
+* Only raise ``not-callable`` when all the inferred values of a property are not callable.
+
+  Closes #5931
+
+
+* Fix a false negative for ``subclassed-final-class`` when a set of other messages were disabled.
+
+
+What's New in Pylint 2.13.4?
+============================
+Release date: 2022-03-31
+
+* Fix false positive regression in 2.13.0 for ``used-before-assignment`` for
+  homonyms between variable assignments in try/except blocks and variables in
+  a comprehension's filter.
+
+  Closes #6035
+
+* Include ``testing_pylintrc`` in source and wheel distributions.
+
+  Closes #6028
+
+* Fix crash in ``super-init-not-called`` checker when using ``ctypes.Union``.
+
+  Closes #6027
+
+
+* Fix crash for ``unneccessary-ellipsis`` checker when an ellipsis is used inside of a container or a lambda expression.
+
+  Closes #6036
+  Closes #6037
+  Closes #6048
+
+
+What's New in Pylint 2.13.3?
+============================
+Release date: 2022-03-29
+
+* Fix false positive for ``unnecessary-ellipsis`` when using an ellipsis as a default argument.
+
+  Closes #5973
+
+* Fix crash involving unbalanced tuple unpacking.
+
+  Closes #5998
+
+* Fix false positive for 'nonexistent-operator' when repeated '-' are
+  separated (e.g. by parens).
+
+  Closes #5769
+
+
+What's New in Pylint 2.13.2?
+============================
+Release date: 2022-03-27
+
+* Fix crash when subclassing a ``namedtuple``.
+
+  Closes #5982
+
+* Fix false positive for ``superfluous-parens`` for patterns like
+  "return (a or b) in iterable".
+
+  Closes #5803
+
+* Fix a false negative regression in 2.13.0 where ``protected-access`` was not
+  raised on functions.
+
+  Fixes #5989
+
+* Better error messages in case of crash if pylint can't write the issue template.
+
+  Refer to #5987
+
+
+What's New in Pylint 2.13.1?
+============================
+Release date: 2022-03-26
+
+* Fix a regression in 2.13.0 where ``used-before-assignment`` was emitted for
+  the usage of a nonlocal in a try block.
+
+  Fixes #5965
+
+* Avoid emitting ``raising-bad-type`` when there is inference ambiguity on
+  the variable being raised.
+
+  Closes #2793
+
+* Loosen TypeVar default name pattern a bit to allow names with multiple uppercase
+  characters. E.g. ``HVACModeT`` or ``IPAddressT``.
+
+  Closes #5981
+
+* Fixed false positive for ``unused-argument`` when a ``nonlocal`` name is used
+  in a nested function that is returned without being called by its parent.
+
+  Closes #5187
+
+* Fix program crash for ``modified_iterating-list/set/dict`` when the list/dict/set
+  being iterated through is a function call.
+
+  Closes #5969
+
+* Don't emit ``broken-noreturn`` and ``broken-collections-callable`` errors
+  inside ``if TYPE_CHECKING`` blocks.
+
+
+What's New in Pylint 2.13.0?
+============================
+Release date: 2022-03-24
+
+* Add missing dunder methods to ``unexpected-special-method-signature`` check.
+
+* No longer emit ``no-member`` in for loops that reference ``self`` if the binary operation that
+  started the for loop uses a ``self`` that is encapsulated in tuples or lists.
+
+  Ref PyCQA/astroid#1360
+  Closes #4826
+
+* Output better error message if unsupported file formats are used with ``pyreverse``.
+
+  Closes #5950
+
+* Fix pyreverse diagrams type hinting for classmethods and staticmethods.
+
+* Fix pyreverse diagrams type hinting for methods returning None.
+
+* Fix matching ``--notes`` options that end in a non-word character.
+
+  Closes #5840
+
+* Updated the position of messages for class and function defintions to no longer cover
+  the complete definition. Only the ``def`` or ``class`` + the name of the class/function
+  are covered.
+
+  Closes #5466
+
+* ``using-f-string-in-unsupported-version`` and ``using-final-decorator-in-unsupported-version`` msgids
+    were renamed from ``W1601`` and ``W1602`` to ``W2601`` and ``W2602``. Disabling using these msgids will break.
+    This is done in order to restore consistency with the already existing msgids for ``apply-builtin`` and
+    ``basestring-builtin`` from the now deleted python 3K+ checker. There is now a check that we're not using
+    existing msgids or symbols from deleted checkers.
+
+  Closes #5729
+
+* The line numbering for messages related to function arguments is now more accurate. This can
+  require some message disables to be relocated to updated positions.
+
+* Add ``--recursive`` option to allow recursive discovery of all modules and packages in subtree. Running pylint with
+  ``--recursive=y`` option will check all discovered ``.py`` files and packages found inside subtree of directory provided
+  as parameter to pylint.
+
+  Closes #352
+
+* Add ``modified-iterating-list``, ``modified-iterating-dict`` and ``modified-iterating-set``,
+  emitted when items are added to or removed from respectively a list, dictionary or
+  set being iterated through.
+
+  Closes #5348
+
+* Fix false-negative for ``assignment-from-none`` checker using list.sort() method.
+
+  closes #5722
+
+* New extension ``import-private-name``: indicate imports of external private packages
+  and objects (prefixed with ``_``). It can be loaded using ``load-plugins=pylint.extensions.private_import``.
+
+  Closes #5463
+
+* Fixed crash from ``arguments-differ`` and ``arguments-renamed`` when methods were
+  defined outside the top level of a class.
+
+  Closes #5648
+
+* Removed the deprecated ``check_docs`` extension. You can use the ``docparams`` checker
+  to get the checks previously included in ``check_docs``.
+
+  Closes #5322
+
+* Added a ``testutil`` extra require to the packaging, as ``gitpython`` should not be a dependency
+  all the time but is still required to use the primer helper code in ``pylint.testutil``. You can
+  install it with ``pip install pylint[testutil]``.
+
+  Closes #5486
+
+* Reinstated checks from the python3 checker that are still useful for python 3
+  (``eq-without-hash``). This is now in the ``pylint.extensions.eq_without_hash`` optional
+  extension.
+
+  Closes #5025
+
+* Fixed an issue where ``ungrouped-imports`` could not be disabled without raising
+  ``useless-suppression``.
+
+  Ref #2366
+
+* Added several checkers to deal with unicode security issues
+  (see `Trojan Sources <https://trojansource.codes/>`_ and
+  `PEP 672 <https://www.python.org/dev/peps/pep-0672/>`_ for details) that also
+  concern the readability of the code. In detail the following checks were added:
+
+  * ``bad-file-encoding`` checks that the file is encoded in UTF-8 as suggested by
+    `PEP8 <https://www.python.org/dev/peps/pep-0008/#id20>`_.
+    UTF-16 and UTF-32 are `not supported by Python <https://bugs.python.org/issue1503789>`_
+    at the moment. If this ever changes
+    ``invalid-unicode-codec`` checks that they aren't used, to allow for backwards
+    compatibility.
+
+  * ``bidirectional-unicode`` checks for bidirectional unicode characters that
+    could make code execution different than what the user expects.
+
+  * ``invalid-character-backspace``, ``invalid-character-carriage-return``,
+    ``invalid-character-sub``, ``invalid-character-esc``,
+    ``invalid-character-zero-width-space`` and ``invalid-character-nul``
+    to check for possibly harmful unescaped characters.
+
+  Closes #5281
+
+* Use the ``tomli`` package instead of ``toml`` to parse ``.toml`` files.
+
+ Closes #5885
+
+* Fix false positive - Allow unpacking of ``self`` in a subclass of ``typing.NamedTuple``.
+
+ Closes #5312
+
+* Fixed false negative ``unpacking-non-sequence`` when value is an empty list.
+
+ Closes #5707
+
+* Better warning messages for useless else or elif when a function returns early.
+
+  Closes #5614
+
+* Fixed false positive ``consider-using-dict-comprehension`` when creating a dict
+  using a list of tuples where key AND value vary depending on the same condition.
+
+  Closes #5588
+
+* Fixed false positive for ``global-variable-undefined`` when ``global`` is used with a class name
+
+  Closes #3088
+
+* Fixed false positive for ``unused-variable`` when a ``nonlocal`` name is assigned as part of a multi-name assignment.
+
+  Closes #3781
+
+* Fixed a crash in ``unspecified-encoding`` checker when providing ``None``
+  to the ``mode`` argument of an ``open()`` call.
+
+  Closes #5731
+
+* Fixed a crash involving a ``NewType`` named with an f-string.
+
+  Closes #5770
+  Ref PyCQA/astroid#1400
+
+* Improved ``bad-open-mode`` message when providing ``None`` to the ``mode``
+  argument of an ``open()`` call.
+
+  Closes #5733
+
+* Added ``lru-cache-decorating-method`` checker with checks for the use of ``functools.lru_cache``
+  on class methods. This is unrecommended as it creates memory leaks by never letting the instance
+  getting garbage collected.
+
+  Closes #5670
+
+* Fixed crash with recursion error for inference of class attributes that referenced
+  the class itself.
+
+  Closes #5408
+  Ref PyCQA/astroid#1392
+
+* Fixed false positive for ``unused-argument`` when a method overridden in a subclass
+  does nothing with the value of a keyword-only argument.
+
+  Closes #5771
+  Ref PyCQA/astroid#1382
+
+* The issue template for crashes is now created for crashes which were previously not covered
+  by this mechanism.
+
+  Closes #5668
+
+* Rewrote checker for ``non-ascii-name``.
+   It now ensures __all__ Python names are ASCII and also properly
+   checks the names of imports (``non-ascii-module-import``) as
+   well as file names (``non-ascii-file-name``) and emits their respective new warnings.
+
+   Non ASCII characters could be homoglyphs (look alike characters) and hard to
+   enter on a non specialized keyboard.
+   See `Confusable Characters in PEP 672 <https://www.python.org/dev/peps/pep-0672/#confusable-characters-in-identifiers>`_
+
+* When run in parallel mode ``pylint`` now pickles the data passed to subprocesses with
+  the ``dill`` package. The ``dill`` package has therefore been added as a dependency.
+
+* An astroid issue where symlinks were not being taken into account
+  was fixed
+
+  Closes #1470
+  Closes #3499
+  Closes #4302
+  Closes #4798
+  Closes #5081
+
+* Fix a crash in ``unused-private-member`` checker when analyzing code using
+  ``type(self)`` in bound methods.
+
+  Closes #5569
+
+* Optimize parsing of long lines when ``missing-final-newline`` is enabled.
+
+  Closes #5724
+
+* Fix false positives for ``used-before-assignment`` from using named
+  expressions in a ternary operator test and using that expression as
+  a call argument.
+
+  Closes #5177, #5212
+
+* Fix false positive for ``undefined-variable`` when ``namedtuple`` class
+  attributes are used as return annotations.
+
+  Closes #5568
+
+* Fix false negative for ``undefined-variable`` and related variable messages
+  when the same undefined variable is used as a type annotation and is
+  accessed multiple times, or is used as a default argument to a function.
+
+  Closes #5399
+
+* Pyreverse - add output in mermaidjs format
+
+* Emit ``used-before-assignment`` instead of ``undefined-variable`` when attempting
+  to access unused type annotations.
+
+  Closes #5713
+
+* Added confidence level ``CONTROL_FLOW`` for warnings relying on assumptions
+  about control flow.
+
+* ``used-before-assignment`` now considers that assignments in a try block
+  may not have occurred when the except or finally blocks are executed.
+
+  Closes #85, #2615
+
+* Fixed false negative for ``used-before-assignment`` when a conditional
+  or context manager intervened before the try statement that suggested
+  it might fail.
+
+  Closes #4045
+
+* Fixed false negative for ``used-before-assignment`` in finally blocks
+  if an except handler did not define the assignment that might have failed
+  in the try block.
+
+* Fixed extremely long processing of long lines with comma's.
+
+  Closes #5483
+
+* Fixed crash on properties and inherited class methods when comparing them for
+  equality against an empty dict.
+
+  Closes #5646
+
+* Fixed a false positive for ``assigning-non-slot`` when the slotted class
+  defined ``__setattr__``.
+
+  Closes #3793
+
+* Fixed a false positive for ``invalid-class-object`` when the object
+  being assigned to the ``__class__`` attribute is uninferable.
+
+* Fixed false positive for ``used-before-assignment`` with self-referential type
+  annotation in conditional statements within class methods.
+
+  Closes #5499
+
+* Add checker ``redefined-slots-in-subclass``: Emitted when a slot is redefined in a subclass.
+
+  Closes #5617
+
+* Fixed false positive for ``global-variable-not-assigned`` when the ``del`` statement is used
+
+  Closes #5333
+
+* By default, pylint does no longer take files starting with ``.#`` into account. Those are
+  considered `emacs file locks`. See
+  https://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html.
+  This behavior can be reverted by redefining the ``ignore-patterns`` option.
+
+  Closes #367
+
+* Fixed a false positive for ``used-before-assignment`` when a named expression
+  appears as the first value in a container.
+
+  Closes #5112
+
+* ``used-before-assignment`` now assumes that assignments in except blocks
+  may not have occurred and warns accordingly.
+
+  Closes #4761
+
+* When evaluating statements after an except block, ``used-before-assignment``
+  assumes that assignments in the except blocks took place if the
+  corresponding try block contained a return statement.
+
+  Closes #5500
+
+* Fixed a false negative for ``used-before-assignment`` when some but not all
+  except handlers defined a name relied upon after an except block when the
+  corresponding try block contained a return statement.
+
+  Closes #5524
+
+* When evaluating statements in the ``else`` clause of a loop, ``used-before-assignment``
+  assumes that assignments in the except blocks took place if the
+  except handlers constituted the only ways for the loop to finish without
+  breaking early.
+
+  Closes #5683
+
+* ``used-before-assignment`` now checks names in try blocks.
+
+* Fixed false positive with ``used-before-assignment`` for assignment expressions
+  in lambda statements.
+
+  Closes #5360, #3877
+
+* Fixed a false positive (affecting unreleased development) for
+  ``used-before-assignment`` involving homonyms between filtered comprehensions
+  and assignments in except blocks.
+
+  Closes #5586
+
+* Fixed crash with slots assignments and annotated assignments.
+
+  Closes #5479
+
+* Fixed crash on list comprehensions that used ``type`` as inner variable name.
+
+  Closes #5461
+
+* Fixed crash in ``use-maxsplit-arg`` checker when providing the ``sep`` argument
+  to ``str.split()`` by keyword.
+
+  Closes #5737
+
+* Fix false positive for ``unused-variable`` for a comprehension variable matching
+  an outer scope type annotation.
+
+  Closes #5326
+
+* Fix false negative for ``undefined-variable`` for a variable used multiple times
+  in a comprehension matching an unused outer scope type annotation.
+
+  Closes #5654
+
+* Some files in ``pylint.testutils`` were deprecated. In the future imports should be done from the
+  ``pylint.testutils.functional`` namespace directly.
+
+* Fixed false positives for ``no-value-for-parameter`` with variadic
+  positional arguments.
+
+  Closes #5416
+
+* ``safe_infer`` no longer makes an inference when given two function
+  definitions with differing numbers of arguments.
+
+  Closes #3675
+
+* Fix ``comparison-with-callable`` false positive for callables that raise, such
+  as typing constants.
+
+  Closes #5557
+
+* Fixed a crash on ``__init__`` nodes when the attribute was previously uninferable due to a cache
+  limit size. This limit can be hit when the inheritance pattern of a class (and therefore of the ``__init__`` attribute) is very large.
+
+  Closes #5679
+
+* Fix false positive for ``used-before-assignment`` from a class definition
+  nested under a function subclassing a class defined outside the function.
+
+  Closes #4590
+
+* Fix ``unnecessary_dict_index_lookup`` false positive when deleting a dictionary's entry.
+
+  Closes #4716
+
+* Fix false positive for ``used-before-assignment`` when an except handler
+  shares a name with a test in a filtered comprehension.
+
+  Closes #5817
+
+* Fix crash in ``unnecessary-dict-index-lookup`` checker if the output of
+  ``items()`` is assigned to a 1-tuple.
+
+  Closes #5504
+
+* When invoking ``pylint``, ``epylint``, ``symilar`` or ``pyreverse`` by importing them in a python file
+  you can now pass an ``argv`` keyword besides patching ``sys.argv``.
+
+  Closes #5320
+
+* The ``PyLinter`` class will now be initialized with a ``TextReporter``
+  as its reporter if none is provided.
+
+* Fix ``super-init-not-called`` when parent or ``self`` is a ``Protocol``
+
+  Closes #4790
+
+* Fix false positive ``not-callable`` with attributes that alias ``NamedTuple``
+
+  Partially closes #1730
+
+* Emit ``redefined-outer-name`` when a nested except handler shadows an outer one.
+
+  Closes #4434
+  Closes #5370
+
+* Fix false positive ``super-init-not-called`` for classes that inherit their ``init`` from
+  a parent.
+
+  Closes #4941
+
+* ``encoding`` can now be supplied as a positional argument to calls that open
+  files without triggering ``unspecified-encoding``.
+
+  Closes #5638
+
+* Fatal errors now emit a score of 0.0 regardless of whether the linted module
+  contained any statements
+
+  Closes #5451
+
+* ``fatal`` was added to the variables permitted in score evaluation expressions.
+
+* The default score evaluation now uses a floor of 0.
+
+  Closes #2399
+
+* Fix false negative for ``consider-iterating-dictionary`` during membership checks encapsulated in iterables
+  or ``not in`` checks
+
+  Closes #5323
+
+* Fixed crash on uninferable decorators on Python 3.6 and 3.7
+
+* Add checker ``unnecessary-ellipsis``: Emitted when the ellipsis constant is used unnecessarily.
+
+  Closes #5460
+
+* Disable checker ``bad-docstring-quotes`` for Python <= 3.7, because in these versions the line
+  numbers for decorated functions and classes are not reliable which interferes with the checker.
+
+  Closes #3077
+
+* Fixed incorrect classification of Numpy-style docstring as Google-style docstring for
+  docstrings with property setter documentation.
+  Docstring classification is now based on the highest amount of matched sections instead
+  of the order in which the docstring styles were tried.
+
+* Fixed detection of ``arguments-differ`` when superclass static
+  methods lacked a ``@staticmethod`` decorator.
+
+  Closes #5371
+
+* ``TypingChecker``
+
+  * Added new check ``broken-noreturn`` to detect broken uses of ``typing.NoReturn``
+    if ``py-version`` is set to Python ``3.7.1`` or below.
+    https://bugs.python.org/issue34921
+
+  * Added new check ``broken-collections-callable`` to detect broken uses of ``collections.abc.Callable``
+    if ``py-version`` is set to Python ``3.9.1`` or below.
+    https://bugs.python.org/issue42965
+
+* The ``testutils`` for unittests now accept ``end_lineno`` and ``end_column``. Tests
+  without these will trigger a ``DeprecationWarning``.
+
+* ``arguments-differ`` will no longer complain about method redefinitions with extra parameters
+  that have default values.
+
+  Closes #1556, #5338
+
+* Fixed false positive ``unexpected-keyword-arg`` for decorators.
+
+  Closes #258
+
+* Importing the deprecated stdlib module ``xml.etree.cElementTree`` now emits ``deprecated_module``.
+
+  Closes #5862
+
+* Disables for ``deprecated-module`` and similar warnings for stdlib features deprecated
+  in newer versions of Python no longer raise ``useless-suppression`` when linting with
+  older Python interpreters where those features are not yet deprecated.
+
+* Importing the deprecated stdlib module ``distutils`` now emits ``deprecated_module`` on Python 3.10+.
+
+* ``missing-raises-doc`` will now check the class hierarchy of the raised exceptions
+
+  .. code-block:: python
+
+    def my_function()
+      """My function.
+
+      Raises:
+        Exception: if something fails
+      """
+      raise ValueError
+
+  Closes #4955
+
+* Allow disabling ``duplicate-code`` with a disable comment when running through
+  pylint.
+
+  Closes #214
+
+* Improve ``invalid-name`` check for ``TypeVar`` names.
+  The accepted pattern can be customized with ``--typevar-rgx``.
+
+  Closes #3401
+
+* Added new checker ``typevar-name-missing-variance``. Emitted when a covariant
+  or contravariant ``TypeVar`` does not end with  ``_co`` or ``_contra`` respectively or
+  when a ``TypeVar`` is not either but has a suffix.
+
+* Allow usage of mccabe 0.7.x release
+
+  Closes #5878
+
+* Fix ``unused-private-member`` false positive when accessing private methods through ``property``.
+
+  Closes #4756
+
+
+What's New in Pylint 2.12.2?
+============================
+Release date: 2021-11-25
+
+* Fixed a false positive for ``unused-import`` where everything
+  was not analyzed properly inside typing guards.
+
+* Fixed a false-positive regression for ``used-before-assignment`` for
+  typed variables in the body of class methods that reference the same class
+
+  Closes #5342
+
+* Specified that the ``ignore-paths`` option considers "\" to represent a
+  windows directory delimiter instead of a regular expression escape
+  character.
+
+* Fixed a crash with the ``ignore-paths`` option when invoking the option
+  via the command line.
+
+  Closes #5437
+
+* Fixed handling of Sphinx-style parameter docstrings with asterisks. These
+  should be escaped with by prepending a "\".
+
+  Closes #5406
+
+* Add ``endLine`` and ``endColumn`` keys to output of ``JSONReporter``.
+
+  Closes #5380
+
+* Fixed handling of Google-style parameter specifications where descriptions
+  are on the line following the parameter name. These were generating
+  false positives for ``missing-param-doc``.
+
+  Closes #5452
+
+* Fix false negative for ``consider-iterating-dictionary`` during membership checks encapsulated in iterables
+  or ``not in`` checks
+
+  Closes #5323
+
+* ``unused-import`` now check all ancestors for typing guards
+
+  Closes #5316
+
+
+What's New in Pylint 2.12.1?
+============================
+Release date: 2021-11-25
+
+* Require Python ``3.6.2`` to run pylint.
+
+  Closes #5065
+
+
+What's New in Pylint 2.12.0?
+============================
+Release date: 2021-11-24
+
+* Upgrade astroid to 2.9.0
+
+  Closes #4982
+
+* Add ability to add ``end_line`` and ``end_column`` to the ``--msg-template`` option.
+  With the standard ``TextReporter`` this will add the line and column number of the
+  end of a node to the output of Pylint. If these numbers are unknown, they are represented
+  by an empty string.
+
+* Introduced primer tests and a configuration tests framework. The helper classes available in
+  ``pylint/testutil/`` are still unstable and might be modified in the near future.
+
+  Closes #4412 #5287
+
+* Fix ``install graphiz`` message which isn't needed for puml output format.
+
+* ``MessageTest`` of the unittest ``testutil`` now requires the ``confidence`` attribute
+  to match the expected value. If none is provided it is set to ``UNDEFINED``.
+
+* ``add_message`` of the unittest ``testutil`` now actually handles the ``col_offset`` parameter
+  and allows it to be checked against actual output in a test.
+
+* Fix a crash in the ``check_elif`` extensions where an undetected if in a comprehension
+  with an if statement within a f-string resulted in an out of range error. The checker no
+  longer relies on counting if statements anymore and uses known if statements locations instead.
+  It should not crash on badly parsed if statements anymore.
+
+* Fix ``simplify-boolean-expression`` when condition can be inferred as False.
+
+  Closes #5200
+
+* Fix exception when pyreverse parses ``property function`` of a class.
+
+* The functional ``testutils`` now accept ``end_lineno`` and ``end_column``. Expected
+  output files without these will trigger a ``DeprecationWarning``. Expected output files
+  can be easily updated with the ``python tests/test_functional.py --update-functional-output`` command.
+
+* The functional ``testutils`` now correctly check the distinction between ``HIGH`` and
+  ``UNDEFINED`` confidence. Expected output files without defined ``confidence`` levels will now
+  trigger a ``DeprecationWarning``. Expected output files can be easily updated with the
+  ``python tests/test_functional.py --update-functional-output`` command.
+
+* The functional test runner now supports the option ``min_pyver_end_position`` to control on which python
+  versions the ``end_lineno`` and ``end_column`` attributes should be checked. The default value is 3.8.
+
+* Fix ``accept-no-yields-doc`` and ``accept-no-return-doc`` not allowing missing ``yield`` or
+  ``return`` documentation when a docstring is partially correct
+
+  Closes #5223
+
+* Add an optional extension ``consider-using-any-or-all`` : Emitted when a ``for`` loop only
+  produces a boolean and could be replaced by ``any`` or ``all`` using a generator. Also suggests
+  a suitable any or all statement.
+
+  Closes #5008
+
+* Properly identify parameters with no documentation and add new message called ``missing-any-param-doc``
+
+  Closes #3799
+
+* Add checkers ``overridden-final-method`` & ``subclassed-final-class``
+
+  Closes #3197
+
+* Fixed ``protected-access`` for accessing of attributes and methods of inner classes
+
+  Closes #3066
+
+* Added support for ``ModuleNotFoundError`` (``import-error`` and ``no-name-in-module``).
+  ``ModuleNotFoundError`` inherits from ``ImportError`` and was added in Python ``3.6``
+
+* ``undefined-variable`` now correctly flags variables which only receive a type annotations
+  and never get assigned a value
+
+  Closes #5140
+
+* ``undefined-variable`` now correctly considers the line numbering and order of classes
+  used in metaclass declarations
+
+  Closes #4031
+
+* ``used-before-assignment`` now correctly considers references to classes as type annotation
+  or default values in first-level methods
+
+  Closes #3771
+
+* ``undefined-variable`` and ``unused-variable`` now correctly trigger for assignment expressions
+  in functions defaults
+
+  Fixes part of #3688
+
+* ``undefined-variable`` now correctly triggers for assignment expressions in if ... else statements
+  This includes a basic form of control flow inference for if ... else statements using
+  constant boolean values
+
+  Closes #3688
+
+* Added the ``--enable-all-extensions`` command line option. It will load all available extensions
+  which can be listed by running ``--list-extensions``
+
+* Fix bug with importing namespace packages with relative imports
+
+  Closes #2967 and #5131
+
+* Improve and flatten ``unused-wildcard-import`` message
+
+  Closes #3859
+
+* In length checker, ``len-as-condition`` has been renamed as
+  ``use-implicit-booleaness-not-len`` in order to be consistent with
+  ``use-implicit-booleaness-not-comparison``.
+
+* Created new ``UnsupportedVersionChecker`` checker class that includes checks for features
+  not supported by all versions indicated by a ``py-version``.
+
+  * Added ``using-f-string-in-unsupported-version`` checker. Issued when ``py-version``
+    is set to a version that does not support f-strings (< 3.6)
+
+* Fix ``useless-super-delegation`` false positive when default keyword argument is a variable.
+
+* Properly emit ``duplicate-key`` when Enum members are duplicate dictionary keys
+
+  Closes #5150
+
+* Use ``py-version`` setting for alternative union syntax check (PEP 604),
+  instead of the Python interpreter version.
+
+* Subclasses of ``dict`` are regarded as reversible by the ``bad-reversed-sequence`` checker
+  (Python 3.8 onwards).
+
+  Closes #4981
+
+* Support configuring mixin class pattern via ``mixin-class-rgx``
+
+* Added new checker ``use-implicit-booleaness-not-comparison``: Emitted when
+  collection literal comparison is being used to check for emptiness.
+
+  Closes #4774
+
+* ``mising-param-doc`` now correctly parses asterisks for variable length and
+  keyword parameters
+
+  Closes #3733
+
+* ``mising-param-doc`` now correctly handles Numpy parameter documentation without
+  explicit typing
+
+  Closes #5222
+
+* ``pylint`` no longer crashes when checking assignment expressions within if-statements
+
+  Closes #5178
+
+* Update ``literal-comparison``` checker to ignore tuple literals
+
+  Closes #3031
+
+* Normalize the input to the ``ignore-paths`` option to allow both Posix and
+  Windows paths
+
+  Closes #5194
+
+* Fix double emitting of ``not-callable`` on inferable ``properties``
+
+  Closes #4426
+
+* ``self-cls-assignment`` now also considers tuple assignment
+
+* Fix ``missing-function-docstring`` not being able to check ``__init__`` and other
+  magic methods even if the ``no-docstring-rgx`` setting was set to do so
+
+* Added ``using-final-decorator-in-unsupported-version`` checker. Issued when ``py-version``
+  is set to a version that does not support ``typing.final`` (< 3.8)
+
+* Added configuration option ``exclude-too-few-public-methods`` to allow excluding
+  classes from the ``min-public-methods`` checker.
+
+  Closes #3370
+
+* The ``--jobs`` parameter now fallbacks to 1 if the host operating system does not
+  have functioning shared semaphore implementation.
+
+  Closes #5216
+
+* Fix crash for ``unused-private-member`` when checking private members on ``__class__``
+
+  Closes #5261
+
+* Crashes when a list is encountered in a toml configuration do not happen anymore.
+
+  Closes #4580
+
+* Moved ``misplaced-comparison-constant`` to its own extension ``comparison_placement``.
+  This checker was opinionated and now no longer a default. It can be reactived by adding
+  ``pylint.extensions.comparison_placement`` to ``load-plugins`` in your config.
+
+  Closes #1064
+
+* A new ``bad-configuration-section`` checker was added that will emit for misplaced option
+  in pylint's top level namespace for toml configuration. Top-level dictionaries or option defined
+  in the wrong section will still silently not be taken into account, which is tracked in a
+  follow-up issue.
+
+  Follow-up in #5259
+
+* Fix crash for ``protected-access`` on (outer) class traversal
+
+* Added new checker ``useless-with-lock`` to find incorrect usage of with statement and threading module locks.
+  Emitted when ``with threading.Lock():`` is used instead of ``with lock_instance:``.
+
+  Closes #5208
+
+* Make yn validator case insensitive, to allow for ``True`` and ``False`` in config files.
+
+* Fix crash on ``open()`` calls when the ``mode`` argument is not a simple string.
+
+  Partially closes #5321
+
+* Inheriting from a class that implements ``__class_getitem__`` no longer raises ``inherit-non-class``.
+
+* Pyreverse - Add the project root directory to sys.path
+
+  Closes #2479
+
+* Don't emit ``consider-using-f-string`` if ``py-version`` is set to Python < ``3.6``.
+  ``f-strings`` were added in Python ``3.6``
+
+  Closes #5019
+
+* Fix regression for ``unspecified-encoding`` with ``pathlib.Path.read_text()``
+
+  Closes #5029
+
+* Don't emit ``consider-using-f-string`` if the variables to be interpolated include a backslash
+
+* Fixed false positive for ``cell-var-from-loop`` when variable is used as the default
+  value for a keyword-only parameter.
+
+  Closes #5012
+
+* Fix false-positive ``undefined-variable`` with ``Lambda``, ``IfExp``, and
+  assignment expression.
+
+* Fix false-positive ``useless-suppression`` for ``wrong-import-order``
+
+  Closes #2366
+
+* Fixed ``toml`` dependency issue
+
+  Closes #5066
+
+* Fix false-positive ``useless-suppression`` for ``line-too-long``
+
+  Closes #4212
+
+* Fixed ``invalid-name`` not checking parameters of overwritten base ``object`` methods
+
+  Closes #3614
+
+* Fixed crash in ``consider-using-f-string`` if ``format`` is not called
+
+  Closes #5058
+
+* Fix crash with ``AssignAttr`` in ``if TYPE_CHECKING`` blocks.
+
+  Closes #5111
+
+* Improve node information for ``invalid-name`` on function argument.
+
+* Prevent return type checkers being called on functions with ellipses as body
+
+  Closes #4736
+
+* Add ``is_sys_guard`` and ``is_typing_guard`` helper functions from astroid
+  to ``pylint.checkers.utils``.
+
+* Fix regression on ClassDef inference
+
+  Closes #5030
+  Closes #5036
+
+* Fix regression on Compare node inference
+
+  Closes #5048
+
+* Fix false-positive ``isinstance-second-argument-not-valid-type`` with ``typing.Callable``.
+
+  Closes #3507
+  Closes #5087
+
+* It is now recommended to do ``pylint`` development on ``Python`` 3.8 or higher. This
+  allows using the latest ``ast`` parser.
+
+* All standard jobs in the ``pylint`` CI now run on ``Python`` 3.8 by default. We still
+  support python 3.6 and 3.7 and run tests for those interpreters.
+
+* ``TypingChecker``
+
+  * Fix false-negative for ``deprecated-typing-alias`` and ``consider-using-alias``
+    with ``typing.Type`` + ``typing.Callable``.
+
+
 What's New in Pylint 2.11.1?
 ============================
 Release date: 2021-09-16
 
-..
-  Put bug fixes that should not wait for a new minor version here
-
 * ``unspecified-encoding`` now checks the encoding of ``pathlib.Path()`` correctly
 
   Closes #5017
@@ -46,7 +1079,7 @@ Release date: 2021-09-16
   Closes #4776
 
 
-* Added ``py-version`` config key (if ``[MASTER]`` section). Used for version dependant checks.
+* Added ``py-version`` config key (if ``[MASTER]`` section). Used for version dependent checks.
   Will default to whatever Python version pylint is executed with.
 
 * ``CodeStyleChecker``
@@ -65,7 +1098,7 @@ Release date: 2021-09-16
 
   Closes #4751
 
-* https is now prefered in the documentation and http://pylint.pycqa.org correctly redirect to https://pylint.pycqa.org
+* https is now preferred in the documentation and http://pylint.pycqa.org correctly redirect to https://pylint.pycqa.org
 
   Closes #3802
 
@@ -279,7 +1312,7 @@ Release date: 2021-08-20
 * Fixed bug with ``cell-var-from-loop`` checker: it no longer has false negatives when
   both ``unused-variable`` and ``used-before-assignment`` are disabled.
 
-* Fix false postive for ``invalid-all-format`` if the list or tuple builtin functions are used
+* Fix false positive for ``invalid-all-format`` if the list or tuple builtin functions are used
 
   Closes #4711
 
@@ -337,7 +1370,7 @@ Release date: 2021-07-21
 
   Closes #4732
 
-* Fix a crash when a AttributeInferenceError was not handled properly when
+* Fix a crash when an AttributeInferenceError was not handled properly when
   failing to infer the real name of an import in astroid.
 
   Closes #4692
@@ -1007,7 +2040,7 @@ Release date: 2021-02-21
 
   Close #3862
 
-* Fix linter multiprocessing pool shutdown (triggered warnings when runned in parallels with other pytest plugins)
+* Fix linter multiprocessing pool shutdown (triggered warnings when ran in parallels with other pytest plugins)
 
   Closes #3779
 
@@ -1034,7 +2067,7 @@ Release date: 2021-02-21
 
   Closes #3468
 
-* Fix ``useless-super-delegation`` false positive when default keyword argument is a dictionnary.
+* Fix ``useless-super-delegation`` false positive when default keyword argument is a dictionary.
 
   Close #3773
 
@@ -2175,7 +3208,7 @@ Release date: 2018-11-25
 
    * Allow ``__module__`` to be redefined at a class level. Close #2451
 
-   * ``pylint`` used to emit a ``unused-variable`` error if unused import was found in the function. Now instead of
+   * ``pylint`` used to emit an ``unused-variable`` error if unused import was found in the function. Now instead of
      ``unused-variable``, ``unused-import`` is emitted.
 
      Close #2421
@@ -3035,7 +4068,7 @@ Release date: 2017-04-13
 
       This message is emitted when pylint finds an one-element tuple,
       created by a stray comma. This can suggest a potential problem in the
-      code and it is recommended to use parantheses in order to emphasise the
+      code and it is recommended to use parentheses in order to emphasise the
       creation of a tuple, rather than relying on the comma itself.
 
     * Don't emit not-callable for instances with unknown bases.
@@ -3735,7 +4768,7 @@ Release date: 2015-11-29
       directory 'test/extensions' and documentation file 'doc/extensions.rst'.
 
     * Added new checker 'extensions.check_docs' that verifies parameter
-      documention in Sphinx, Google, and Numpy style.
+      documentation in Sphinx, Google, and Numpy style.
 
     * Detect undefined variable cases, where the "definition" of an undefined
       variable was in del statement. Instead of emitting used-before-assignment,
@@ -3831,7 +4864,7 @@ Release date: 2015-11-29
       two a binary arithmetic operation is executed between two objects
       which don't support it (a number plus a string for instance).
       This is currently disabled, since the it exhibits way too many false
-      positives, but it will be reenabled as soon as possible.
+      positives, but it will be re-enabled as soon as possible.
 
     * New imported features from astroid into pyreverse: pyreverse.inspector.Project,
       pyreverse.inspector.project_from_files and pyreverse.inspector.interfaces.
@@ -4806,7 +5839,7 @@ Release date: 2012-10-05
 
     * #105337: allow custom reporter in output-format (patch by Kevin Jing Qiu)
 
-    * #104420: check for protocol completness and avoid false R0903
+    * #104420: check for protocol completeness and avoid false R0903
       (patch by Peter Hammond)
 
     * #100654: fix grammatical error for W0332 message (using 'l' as
@@ -4834,7 +5867,7 @@ Release date: 2012-07-17
       except handler contains a tuple of names instead of a single name.
       (patch by tmarek@google.com)
 
-    * #7394: W0212 (access to protected member) not emitted on assigments
+    * #7394: W0212 (access to protected member) not emitted on assignments
       (patch by lothiraldan@gmail.com)
 
     * #18772; no prototype consistency check for mangled methods (patch by
@@ -5429,7 +6462,7 @@ Release date: 2006-03-06
         - the C0101 check with its min-name-length option has
           been removed (this can be specified in the regxp after all...)
         - W0103 and W0121 are now handled by the variables checker
-          (W0103 is now W0603 and W0604 has been splitted into different messages)
+          (W0103 is now W0603 and W0604 has been split into different messages)
         - W0131 and W0132 messages  have been reclassified to C0111 and
           C0112 respectively
         - new W0104 message on statement without effect
@@ -5466,7 +6499,7 @@ Release date: 2006-01-10
       or the default ~/.pylintrc or /etc/pylintrc
 
     * fixed W0706 (Identifier used to raise an exception is assigned...)
-      false positive and reraising a catched exception instance
+      false positive and reraising a caught exception instance
 
     * fixed E0611 (No name get in module blabla) false positive when accessing
       to a class'__dict__
```