### PR TITLE
[ADD] pre-commit-hooks: Add pylint_odoo hook directly to be used from pre-commit.yaml directly

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: pylint_odoo
+    name: Check for Odoo modules using pylint
+    entry: pylint
+    language: python
+    types: [python]
+    require_serial: true


### PR DESCRIPTION
It will allow to add in your pre-commit.yaml directly an entry for pylint_odoo instead of pylint

  .pre-commit-config.yaml

    - repo: https://github.com/OCA/pylint-odoo
      rev: 5.0.5
      hooks:
        - id: pylint_odoo

You can get the current `rev` in the current tags:
 - https://github.com/OCA/pylint-odoo/tags