### PR TITLE
[REF] README: Use new travis URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,8 +222,8 @@ This skip only work with the name of the check, not work with the name of check
 The position of the comment it is not relative to the line that throw the check
 
 
-.. |Build Status| image:: https://travis-ci.org/OCA/pylint-odoo.svg?branch=master
-   :target: https://travis-ci.org/OCA/pylint-odoo
+.. |Build Status| image:: https://app.travis-ci.com/OCA/pylint-odoo.svg?branch=master
+   :target: https://app.travis-ci.com/OCA/pylint-odoo
 .. |Coverage Status| image:: https://coveralls.io/repos/OCA/pylint-odoo/badge.svg?branch=master&service=github
    :target: https://coveralls.io/github/OCA/pylint-odoo?branch=master
 .. |Pypi Package| image:: https://img.shields.io/pypi/v/pylint-odoo.svg


### PR DESCRIPTION
Travis had changed the URL from travis-ci.org to travis-ci.com

This change uses the latest value