### PR TITLE
[FIX] .travis.yml: npm v18.0.0 GLIBC_2.28 not compatible with ubuntu …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ cache:
   directories:
     - $HOME/.cache/pip
 
+# node 18 is not compatible with current ubuntu version used in travis
+# More info about:
+#   - https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/4
+node_js:
+  - 17
+
 matrix:
   include:
     - python: 2.7

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,10 @@ passenv =
 
 commands =
     python --version
-    nodeenv --python-virtualenv
+    # node 18 is not compatible with current ubuntu version used in travis
+    # More info about:
+    #   - https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/4
+    nodeenv --python-virtualenv -n 17.9.0
     npm install -g --no-package-lock --no-save eslint
     eslint --version
     coverage run setup.py test


### PR DESCRIPTION
…used from travis

More info about:
 - https://github.com/nodejs/node/issues/42351#issuecomment-1068424442
 - https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/4