### PR TITLE
[IMP] test-folder-imported: Consider 'from . import test' missing case

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -374,7 +374,12 @@ class ModuleChecker(misc.WrapperModuleChecker):
                 and os.path.basename(node.parent.file) == '__init__.py'):
             package_names = []
             if isinstance(node, astroid.ImportFrom):
-                package_names = node.modname.split('.')[:1]
+                if node.modname:
+                    # from .tests import test_file
+                    package_names = node.modname.split('.')[:1]
+                else:
+                    # from . import tests
+                    package_names = [name for name, alias in node.names]
             elif isinstance(node, astroid.Import):
                 package_names = [name[0].split('.')[0] for name in node.names]
             if "tests" in package_names:

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -78,7 +78,7 @@ EXPECTED_ERRORS = {
     'website-manifest-key-not-valid-uri': 1,
     'character-not-valid-in-resource-link': 2,
     'manifest-maintainers-list': 1,
-    'test-folder-imported': 2,
+    'test-folder-imported': 3,
 }
 
 if six.PY3:

--- a/pylint_odoo/test_repo/broken_module2/__init__.py
+++ b/pylint_odoo/test_repo/broken_module2/__init__.py
@@ -1,1 +1,3 @@
 # -*- coding: utf-8 -*-
+
+from . import tests


### PR DESCRIPTION
The original PR:
 - https://github.com/OCA/pylint-odoo/pull/310

Talks about the following case:
 - https://github.com/OCA/server-tools/blob/cca5dffd0dec68e1aa4209a8747d4381a97efa89/ir_sequence_standard_default/__init__.py#L6

It is using "from . import tests"

But this case of use was not used in the unittest

So, it is not detecting this common case