### PR TITLE
[IMP] duplicate-po-message-definition: Detecting duplicated only with msgid

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -556,10 +556,7 @@ class ModuleChecker(misc.WrapperModuleChecker):
             for entry in po:
                 if entry.obsolete:
                     continue
-                # Using `set` in order to fix false red
-                # if the same entry has duplicated occurrences
-                for occurrence in set(entry.occurrences):
-                    duplicated[(hash(entry.msgid), hash(occurrence))].append(entry)
+                duplicated[hash(entry.msgid)].append(entry)
             for entries in duplicated.values():
                 if len(entries) < 2:
                     continue

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -27,7 +27,7 @@ EXPECTED_ERRORS = {
     'deprecated-openerp-xml-node': 5,
     'development-status-allowed': 1,
     'duplicate-id-csv': 2,
-    'duplicate-po-message-definition': 2,
+    'duplicate-po-message-definition': 3,
     'duplicate-xml-fields': 9,
     'duplicate-xml-record-id': 2,
     'external-request-timeout': 47,

--- a/pylint_odoo/test_repo/broken_module/i18n/es.po
+++ b/pylint_odoo/test_repo/broken_module/i18n/es.po
@@ -12,8 +12,13 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: broken_module
-#: model:ir.model.fields,field_description:broken_module.field_description
 #: model:ir.model.fields,field_description:broken_module.field_wizard_description
+#, python-format
+msgid "Branch"
+msgstr ""
+
+#. module: broken_module
+#: model:ir.model.fields,field_description:broken_module.field_description
 #, python-format
 msgid "Branch"
 msgstr ""


### PR DESCRIPTION
Odoo raises error if the msgid is duplicated even if there are not models entries not duplicated

So, it is considering these kind of cases in order to match with Odoo errors but raising from CI early with static checker

Original PR:
 - https://github.com/OCA/pylint-odoo/pull/290