### PR TITLE
[REF] external-request-timeout: Add ftplib.FTP method

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -310,6 +310,7 @@ DFTL_DEPRECATED_FIELD_PARAMETERS = [
     'digits_compute:digits', 'select:index'
 ]
 DFTL_EXTERNAL_REQUEST_TIMEOUT_METHODS = [
+    "ftplib.FTP",
     "http.client.HTTPConnection",
     "http.client.HTTPSConnection",
     "odoo.addons.iap.models.iap.jsonrpc",

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -30,7 +30,7 @@ EXPECTED_ERRORS = {
     'duplicate-po-message-definition': 3,
     'duplicate-xml-fields': 9,
     'duplicate-xml-record-id': 2,
-    'external-request-timeout': 47,
+    'external-request-timeout': 51,
     'file-not-used': 6,
     'incoherent-interpreter-exec-perm': 3,
     'invalid-commit': 4,

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -36,6 +36,11 @@ import serial as serial_r
 from serial import Serial
 from serial import Serial as Serial_r
 
+import ftplib
+import ftplib as ftplib_r
+from ftplib import FTP
+from ftplib import FTP as ftp_r
+
 from openerp import fields, models, _
 from openerp.exceptions import Warning as UserError
 from openerp import exceptions
@@ -699,6 +704,18 @@ class TestModel(models.Model):
         odoo.addons.iap.models.iap.jsonrpc('http://localhost', timeout=10)
         jsonrpc('http://localhost', timeout=10)
         iap.jsonrpc('http://localhost', timeout=10)
+
+        # FTP  without timeout
+        ftplib.FTP('localhost')
+        ftplib_r.FTP('localhost')
+        FTP('localhost')
+        ftp_r('localhost')
+
+        # FTP valid cases
+        ftplib.FTP('localhost', timeout=10)
+        ftplib_r.FTP('localhost', timeout=10)
+        FTP('localhost', timeout=10)
+        ftp_r('localhost', timeout=10)
 
 
 class NoOdoo(object):


### PR DESCRIPTION
It is better using timeout for this method too as documentation says:
 - https://docs.python.org/es/3/library/ftplib.html#ftplib.FTP_TLS