### PR TITLE
[FIX] Only adds W8113 when field string is the same as title() format

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -659,8 +659,8 @@ class NoModuleChecker(misc.PylintOdooChecker):
                 if (not is_related and isinstance(argument, astroid.Const) and
                     (index ==
                      FIELDS_METHOD.get(argument.parent.func.attrname, 0)) and
-                    (argument.value in
-                     [field_name.capitalize(), field_name.title()])):
+                    (argument.value ==
+                     field_name.title())):
                     self.add_message('attribute-string-redundant', node=node)
                 if isinstance(argument, astroid.Keyword):
                     argument_aux = argument.value
@@ -676,8 +676,7 @@ class NoModuleChecker(misc.PylintOdooChecker):
                     #   of variable
                     elif not is_related and argument.arg == 'string' and \
                         (isinstance(argument_aux, astroid.Const) and
-                         argument_aux.value in
-                         [field_name.capitalize(), field_name.title()]):
+                         argument_aux.value == field_name.title()):
                         self.add_message(
                             'attribute-string-redundant', node=node)
                     elif (argument.arg in deprecated):

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -69,7 +69,7 @@ EXPECTED_ERRORS = {
     'eval-referenced': 5,
     'xml-syntax-error': 2,
     'except-pass': 3,
-    'attribute-string-redundant': 33,
+    'attribute-string-redundant': 31,
     'renamed-field-parameter': 2,
     'deprecated-data-xml-node': 5,
     'xml-deprecated-tree-attribute': 3,


### PR DESCRIPTION
This allows to have titles in different case.

For example this field declaration is not going to set a W8113:

```
has_changes_pending_approval = fields.Boolean(
        string="Has changes pending approval"
)
```

But if we define the field in this way it will set a W8113:

```
has_changes_pending_approval = fields.Boolean(
        string="Has Changes Pending Approval"
)
```

Fixes #387