### PR TITLE
[REF] codecov: Enable codecov again

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 [![Build Status](https://github.com/OCA/pylint-odoo/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/OCA/pylint-odoo/actions/workflows/test.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/OCA/pylint-odoo/branch/main/graph/badge.svg)](https://codecov.io/gh/OCA/pylint-odoo)
-[![version](https://img.shields.io/pypi/v/oca-pylint-odoo.svg)](https://pypi.org/project/oca-pylint-odoo)
-[![wheel](https://img.shields.io/pypi/wheel/oca-pylint-odoo.svg)](https://pypi.org/project/oca-pylint-odoo)
-[![supported-versions](https://img.shields.io/pypi/pyversions/oca-pylint-odoo.svg)](https://pypi.org/project/oca-pylint-odoo)
+[![version](https://img.shields.io/pypi/v/pylint-odoo.svg)](https://pypi.org/project/pylint-odoo)
+[![wheel](https://img.shields.io/pypi/wheel/pylint-odoo.svg)](https://pypi.org/project/pylint-odoo)
+[![supported-versions](https://img.shields.io/pypi/pyversions/pylint-odoo.svg)](https://pypi.org/project/pylint-odoo)
 [![commits-since](https://img.shields.io/github/commits-since/OCA/pylint-odoo/v8.0.1.svg)](https://github.com/OCA/pylint-odoo/compare/v8.0.1...main)
 [![code-style-black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 [//]: # (end-badges)
 
 
-# Pylint Odoo plugin
+# Pylint Odoo plugin
 
 Enable custom checks for Odoo modules.
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
     # Compatible with "tox --parallel" to avoid concurrency
-    COVERAGE_FILE={toxinidir}/.coverage_{envname}
+    # COVERAGE_FILE={toxinidir}/.coverage_{envname}
     COVERAGE_CONTEXT={envname}
 passenv =
     *
@@ -62,7 +62,7 @@ deps = coverage
 skip_install = true
 commands =
     # Workaround https://github.com/tox-dev/tox/issues/1571
-    python -c 'from glob import glob; import subprocess; subprocess.check_call(["coverage", "combine", "--keep"] + glob(".coverage_*"))'
+    python -c 'from glob import glob; import subprocess; [subprocess.check_call(["coverage", "combine", "--keep", i]) for i in glob(".coverage_*")]'
     coverage report
     coverage html
 


### PR DESCRIPTION
tox was using a custom coverage file output in order to be able to run with parallels

But codecov needs to know this file

For now, commenting the parallels option and support no files to combine without errors