### PR TITLE
[REM] eval-referenced: Replaced by eval-used check from pylint

### DIFF
--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -195,7 +195,6 @@ ODOO_MSGS = {
         "renamed-field-parameter",
         CHECK_DESCRIPTION,
     ),
-    "W8112": ('"eval" referenced detected.', "eval-referenced", CHECK_DESCRIPTION),
     "W8113": (
         "The attribute string is redundant. String parameter equal to name of variable",
         "attribute-string-redundant",
@@ -699,10 +698,6 @@ class OdooAddons(BaseChecker):
                     if assign_node.targets[0].as_string() == node.as_string():
                         yield assign_node.value
 
-    @utils.only_required_for_messages("print-used")
-    def visit_print(self, node):
-        self.add_message("print-used", node=node)
-
     @utils.only_required_for_messages(
         "translation-field",
         "invalid-commit",
@@ -1113,16 +1108,6 @@ class OdooAddons(BaseChecker):
             manifest_path = misc.walk_up(node_dirpath, tuple(misc.MANIFEST_FILES), misc.top_path(node_dirpath))
             if manifest_path:
                 self._odoo_inherit_items[(manifest_path, odoo_class_inherit)].add(node)
-
-    @utils.only_required_for_messages("eval-referenced")
-    def visit_name(self, node):
-        """Detect when a "bad" built-in is referenced."""
-        node_infer = utils.safe_infer(node)
-        if not utils.is_builtin_object(node_infer):
-            # Skip not builtin objects
-            return
-        if node_infer.name == "eval":
-            self.add_message("eval-referenced", node=node)
 
     def camelize(self, string2camelize):
         return re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), string2camelize)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,7 +15,6 @@ EXPECTED_ERRORS = {
     "consider-merging-classes-inherited": 2,
     "context-overridden": 3,
     "development-status-allowed": 1,
-    "eval-referenced": 5,
     "except-pass": 3,
     "external-request-timeout": 51,
     "invalid-commit": 4,


### PR DESCRIPTION
The check eval-referenced is heavy to compute since it needs to check

the inferred node for each variable name

eval-used will detect almost of case using this way

eval-referenced detected the following cases:

    my_var = eval

eval-used is only detecting the following cases:

    eval("...")

So, they are less cases but without heavy process

Running the following command:
  - `py-spy record -o /tmp/py_spy.svg --threads --subprocesses -r 89 -- pytest -k test_20_expected_errors`

The heavy process in the profiler result is:
  - https://github.com/OCA/pylint-odoo/blob/e0c9b25d4d8df55ad716862545f8339d297c8d7f/src/pylint_odoo/checkers/odoo_addons.py#L1120
    - <img width="595" alt="Screen Shot 2022-10-23 at 10 35 16" src="https://user-images.githubusercontent.com/6644187/197401337-a788ffc2-b508-4493-bbb1-7a0449bf9cf2.png">


* Removing visit_print deprecated method

