### PR TITLE
[IMP] print-used: Speed-up 'print-used' check avoid inferring

### DIFF
--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -715,7 +715,11 @@ class OdooAddons(BaseChecker):
         "external-request-timeout",
     )
     def visit_call(self, node):
-        if self.linter.is_message_enabled("print-used", node.lineno):
+        if (
+            self.linter.is_message_enabled("print-used", node.lineno)
+            and isinstance(node.func, astroid.Name)
+            and node.func.name == "print"
+        ):
             infer_node = utils.safe_infer(node.func)
             if utils.is_builtin_object(infer_node) and infer_node.name == "print":
                 self.add_message("print-used", node=node)


### PR DESCRIPTION
infer in nodes is a heavy process
It was reduced using only infer for cases where the name of the method is 'print' early

Running the following command:
  - ` py-spy record -o /tmp/py_spy.svg --threads --subprocesses -r 89 -- pytest -k test_20_expected_errors`

The result is:
 - https://github.com/OCA/pylint-odoo/blob/094873f526781cd2384fd338722b453ffc6fc0d5/src/pylint_odoo/checkers/odoo_addons.py#L719
    - <img width="887" alt="Screen Shot 2022-10-23 at 10 48 31" src="https://user-images.githubusercontent.com/6644187/197402003-c459b5dd-99e1-4dc9-946a-2a70659535e6.png">
