### PR TITLE
[REF] openerp-exception-warning: Change to odoo-exception-warning

### DIFF
--- a/testing/resources/test_repo/broken_module/models/broken_model.py
+++ b/testing/resources/test_repo/broken_module/models/broken_model.py
@@ -42,14 +42,14 @@ from ftplib import FTP
 from ftplib import FTP as ftp_r
 
 from openerp import fields, models, _
-from openerp.exceptions import Warning as UserError
+from odoo.exceptions import UserError
 from openerp import exceptions
 
 # Relatives import for odoo addons
-from openerp.addons.broken_module import broken_model as broken_model1
-from openerp.addons import broken_module as broken_module1
-import openerp.addons.broken_module as broken_module2
-import openerp.addons.broken_module.broken_model as broken_model2
+from odoo.addons.broken_module import broken_model as broken_model1
+from odoo.addons import broken_module as broken_module1
+import odoo.addons.broken_module as broken_module2
+import odoo.addons.broken_module.broken_model as broken_model2
 
 import odoo.addons.iap.models.iap.jsonrpc
 from odoo.addons.iap.models.iap import jsonrpc

--- a/testing/resources/test_repo/broken_module/pylint_oca_broken.py
+++ b/testing/resources/test_repo/broken_module/pylint_oca_broken.py
@@ -5,12 +5,12 @@ import openerp
 from openerp import api
 from openerp.api import one, multi
 
-from openerp.exceptions import Warning as UserError  # pylint: disable=W0622
-from openerp.exceptions import Warning as OtherName  # pylint: disable=W0404
-from openerp.exceptions import Warning  # pylint: disable=W0404,W0622
-from openerp.exceptions import (AccessError as AE,  # pylint: disable=W0404
-                                ValidationError,
-                                Warning as UserError2)
+from odoo.exceptions import Warning as UserError  # pylint: disable=W0622
+from odoo.exceptions import Warning as OtherName  # pylint: disable=W0404
+from odoo.exceptions import Warning  # pylint: disable=W0404,W0622
+from odoo.exceptions import (AccessError as AE,  # pylint: disable=W0404
+                             ValidationError,
+                             Warning as UserError2)
 
 
 class snake_case(object):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,7 +33,7 @@ EXPECTED_ERRORS = {
     "missing-readme": 1,
     "missing-return": 1,
     "odoo-addons-relative-import": 4,
-    "openerp-exception-warning": 3,
+    "odoo-exception-warning": 4,
     "print-used": 1,
     "renamed-field-parameter": 2,
     "resource-not-exist": 4,


### PR DESCRIPTION
Odoo v16.0 shows the following message:
 - https://github.com/odoo/odoo/blob/9ba78dad0ccfda3ec955a39cba1b01e35605923a/odoo/exceptions.py#L131

So, this check is still vigent but for odoo instead of openerp


* Change "openerp" import references to "odoo"