### PR TITLE
[REF] tests: Remove 'score'

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,6 +56,7 @@ class MainTest(unittest.TestCase):
         self.default_options = [
             "--load-plugins=pylint_odoo",
             "--reports=no",
+            "--score=no",
             "--msg-template=" '"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"',
             "--output-format=colorized",
             "--rcfile=%s" % os.devnull,


### PR DESCRIPTION
We don't need it and we are not using it

Remove of the tests the following message:

```txt
-------------------------------------------------------------------
Your code has been rated at 7.14/10 (previous run: 10.00/10, -2.86)
```
