### PR TITLE
[REM] class-camelcase: Replaced by invalid-name

### DIFF
--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -125,12 +125,6 @@ ODOO_MSGS = {
     ),
     "C8102": ('Missing required key "%s" in manifest file', "manifest-required-key", CHECK_DESCRIPTION),
     "C8103": ('Deprecated key "%s" in manifest file', "manifest-deprecated-key", CHECK_DESCRIPTION),
-    "C8104": (
-        'Use `CamelCase` "%s" in class name "%s". You can use oca-autopep8 '
-        "of https://github.com/OCA/maintainer-tools to auto fix it.",
-        "class-camelcase",
-        CHECK_DESCRIPTION,
-    ),
     "C8105": ('License "%s" not allowed in manifest file.', "license-allowed", CHECK_DESCRIPTION),
     "C8106": (
         'Wrong Version Format "%s" in manifest file. Regex to match: "%s"',
@@ -1074,12 +1068,6 @@ class OdooAddons(BaseChecker):
         self.check_odoo_relative_import(node)
         self.check_folder_test_imported(node)
 
-    @utils.only_required_for_messages("class-camelcase")
-    def visit_classdef(self, node):
-        camelized = self.camelize(node.name)
-        if camelized != node.name:
-            self.add_message("class-camelcase", node=node, args=(camelized, node.name))
-
     @utils.only_required_for_messages("attribute-deprecated", "consider-merging-classes-inherited")
     def visit_assign(self, node):
         node_left = node.targets[0]
@@ -1113,9 +1101,6 @@ class OdooAddons(BaseChecker):
             manifest_path = misc.walk_up(node_dirpath, tuple(misc.MANIFEST_FILES), misc.top_path(node_dirpath))
             if manifest_path:
                 self._odoo_inherit_items[(manifest_path, odoo_class_inherit)].add(node)
-
-    def camelize(self, string2camelize):
-        return re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), string2camelize)
 
     def get_func_name(self, node):
         func_name = (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,6 @@ from pylint_odoo import misc
 EXPECTED_ERRORS = {
     "attribute-deprecated": 3,
     "attribute-string-redundant": 31,
-    "class-camelcase": 1,
     "consider-merging-classes-inherited": 2,
     "context-overridden": 3,
     "development-status-allowed": 1,


### PR DESCRIPTION
Running the following command:
 - `pylint -d all -e invalid-name testing/resources/test_repo/broken_module/pylint_oca_broken.py`

The output is the following:
  - `testing/resources/test_repo/broken_module/pylint_oca_broken.py:16: [C0103(invalid-name), snake_case] Class name "snake_case" doesn't conform to PascalCase naming style`

It requires the following pylint.cfg entry:

```cfg
[BASIC]
class-naming-style=PascalCase
```
