### PR TITLE
[REF] setup: Match requires-python = ">=3.7.2" from pylint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ summary = Pylint plugin for Odoo
 long_description_content_type = text/markdown
 license = APGL3
 home_page = https://github.com/OCA/pylint-odoo
-requires_python = >=3.6
+requires_python = >=3.7.2
 classifier =
     Development Status :: 6 - Mature
     Environment :: Console


### PR DESCRIPTION
pylint dependency has the following requires-python:
  - [>=3.7.2](https://github.com/PyCQA/pylint/blob/d591cce71cd06b01c5e94ded1a10c6c0fc092d6d/pyproject.toml#L34)

Related to https://github.com/OCA/pylint-odoo/issues/416