### PR TITLE
7.0 - [REF] checks_odoo_module_xml: Allow duplicated fields with 'groups'

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -777,10 +777,11 @@ class ModuleChecker(misc.WrapperModuleChecker):
             all_fields.setdefault(
                 (field_xml, field.attrib.get('context'),
                  field.attrib.get('filter_domain'),
+                 field.attrib.get('groups'),
                  field.getparent()), []).append(field)
         # Remove all keys which not duplicated by excluding them from the
-        return dict(((name, context, filter_domain, parent_node), nodes) for
-                    (name, context, filter_domain, parent_node), nodes in
+        return dict(((name, context, filter_domain, groups, parent_node), nodes) for
+                    (name, context, filter_domain, groups, parent_node), nodes in
                     all_fields.items() if len(nodes) >= 2)
 
     def _check_duplicate_xml_fields(self):

--- a/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
@@ -131,6 +131,9 @@
                         <tree>
                             <field name="name"/>
                             <field name="name"/>
+
+                            <field name="company_id" invisible="1"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </tree>
                     </field>
                     <field name="value_ids">


### PR DESCRIPTION
Related to https://github.com/odoo/odoo/pull/103743
Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/10

Backport of https://github.com/OCA/odoo-pre-commit-hooks/pull/32 to pylint-odoo@7.0