### PR TITLE
[REF] pylint_odoo: Process max_odoo_version and min_odoo_version for checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ Example to test just odoo-lint case:
 
 ``pylint --load-plugins=pylint_odoo -d all -e odoolint {ADDONS-PATH}``
 
+There are checks only valid for a particular Odoo version
+To know what version of odoo are you running pylint needs the parameter
+ - `pylint --load-plugins=pylint_odoo --valid_odoo_versions={YOUR_ODOO_VERSION}`
+
+with particular odoo version e.g. `"16.0"`
+
+Checks valid only for odoo >= 14.0
+
+    translation-format-interpolation
+    translation-format-truncated
+    translation-fstring-interpolation
+    translation-not-lazy
+    translation-too-few-args
+    translation-too-many-args
+    translation-unsupported-format
+
+Checks valid only for odoo <= 13.0
+
+    translation-contains-variable
+
 
 [//]: # (start-example)
 

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -109,6 +109,7 @@ import validators
 from pylint.checkers import BaseChecker, utils
 
 from .. import misc
+from .odoo_base_checker import OdooBaseChecker
 
 CHECK_DESCRIPTION = (
     "You can review guidelines here: "
@@ -346,7 +347,7 @@ PRINTF_PATTERN = re.compile(
 )
 
 
-class OdooAddons(BaseChecker):
+class OdooAddons(OdooBaseChecker, BaseChecker):
 
     _from_imports = None
     name = "odoolint"
@@ -499,6 +500,13 @@ class OdooAddons(BaseChecker):
             },
         ),
     )
+
+    checks_maxmin_odoo_version = {
+        # For v14.0 use custom_logging.py checks e.g. "translation-not-lazy"
+        "translation-contains-variable": {
+            "odoo_maxversion": "13.0",
+        },
+    }
 
     def close(self):
         """Final process get all cached values and add messages"""

--- a/src/pylint_odoo/checkers/odoo_base_checker.py
+++ b/src/pylint_odoo/checkers/odoo_base_checker.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pylint
+from packaging import version
+from pylint.checkers import BaseChecker
+
+from .. import misc
+
+
+class OdooBaseChecker(BaseChecker):
+    # checks_maxmin_odoo_version = {
+    #   check-code: {
+    #       "odoo_minversion": "14.0",
+    #       "odoo_maxversion": "15.0",
+    #   }
+    checks_maxmin_odoo_version: dict[str, str] = {}
+
+    def msgid_or_symbol2symbol(self, msgid_or_symbol):
+        try:
+            msgid = self.linter.msgs_store.message_id_store.get_active_msgids(msgid_or_symbol)[0]
+            return self.linter.msgs_store.message_id_store.get_symbol(msgid)
+        except (pylint.exceptions.UnknownMessageError, IndexError):
+            return None
+
+    def is_odoo_message_enabled(self, msgid):
+        valid_odoo_versions = self.linter.config.valid_odoo_versions
+        if len(valid_odoo_versions) != 1:
+            # It should be defined only one version
+            return True
+        msg_symbol = self.msgid_or_symbol2symbol(msgid)
+        if msg_symbol is None:
+            return True
+        odoo_version = valid_odoo_versions[0]
+        required_odoo_versions = self.checks_maxmin_odoo_version.get(msg_symbol) or {}
+        odoo_minversion = required_odoo_versions.get("odoo_minversion") or misc.DFTL_VALID_ODOO_VERSIONS[0]
+        odoo_maxversion = required_odoo_versions.get("odoo_maxversion") or misc.DFTL_VALID_ODOO_VERSIONS[-1]
+        return version.parse(odoo_minversion) <= version.parse(odoo_version) <= version.parse(odoo_maxversion)
+
+    def add_message(self, msgid, *args, **kwargs):
+        """Emit translation-not-lazy instead of logging-not-lazy"""
+        if not self.is_odoo_message_enabled(msgid):
+            return
+        return super().add_message(msgid, *args, **kwargs)

--- a/src/pylint_odoo/checkers/vim_comment.py
+++ b/src/pylint_odoo/checkers/vim_comment.py
@@ -2,13 +2,15 @@ import tokenize
 
 from pylint.checkers import BaseTokenChecker
 
+from .odoo_base_checker import OdooBaseChecker
+
 ODOO_MSGS = {
     # C->convention R->refactor W->warning E->error F->fatal
     "W8202": ("Use of vim comment", "use-vim-comment", "Better using local vim configuration file"),
 }
 
 
-class VimComment(BaseTokenChecker):
+class VimComment(OdooBaseChecker, BaseTokenChecker):
 
     name = "odoolint"
     msgs = ODOO_MSGS

--- a/testing/resources/test_repo/broken_module/models/broken_model.py
+++ b/testing/resources/test_repo/broken_module/models/broken_model.py
@@ -396,6 +396,10 @@ class TestModel(models.Model):
         _("format truncated %s%", 'param1')
         _("too many args %s", 'param1', 'param2')
 
+        _("multi-positional args without placeholders %s %s", 'param1', 'param2')
+
+        _("multi-positional args without placeholders {} {}".format('param1', 'param2'))
+
         _("String with correct args %s", "param1")
         _("String with correct kwargs %(param1)s", param1="hola")
 


### PR DESCRIPTION
Checks valid only for odoo >= 14.0

    translation-format-interpolation
    translation-format-truncated
    translation-fstring-interpolation
    translation-not-lazy
    translation-too-few-args
    translation-too-many-args
    translation-unsupported-format

Checks valid only for odoo <= 13.0

    translation-contains-variable

The odoo._ method changed from <=13.0 to >=14.0

<=13.0 is not using arguments:
  - https://github.com/odoo/odoo/blob/a03aa23461498bba67/odoo/tools/translate.py#L447

>=14.0 is using arguments:
  - https://github.com/odoo/odoo/blob/6a6e5f92789e1c/odoo/tools/translate.py#L446

So, the checks needs to be compatible with each odoo version related

To know what is the current version of the odoo analyzed is needed to use `pylint --valid_odoo_versions=13.0` option

Related to https://github.com/OCA/pylint-odoo/issues/378
