### PR TITLE
[REF] pylint_odoo: Replace options name from "_" to "-"

### DIFF
--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -354,16 +354,16 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
     msgs = ODOO_MSGS
     options = (
         (
-            "attribute_deprecated",
+            "attribute-deprecated",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
                 "default": DFTL_ATTRIBUTE_DEPRECATED,
-                "help": "List of attributes deprecated, " + "separated by a comma.",
+                "help": "List of attributes deprecated, separated by a comma.",
             },
         ),
         (
-            "cursor_expr",
+            "cursor-expr",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
@@ -372,7 +372,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             },
         ),
         (
-            "deprecated_field_parameters",
+            "deprecated-field-parameters",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
@@ -384,20 +384,20 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
                 '"deprecated_param:" means that "deprecated_param" was '
                 "deprecated and it doesn't have a new alternative. "
                 '"deprecated_param:new_param" means that it was '
-                'deprecated and renamed as "new_param". ',
+                'deprecated and renamed as "new_param".',
             },
         ),
         (
-            "development_status_allowed",
+            "development-status-allowed",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
                 "default": DFTL_DEVELOPMENT_STATUS_ALLOWED,
-                "help": "List of development status allowed in manifest file, " + "separated by a comma.",
+                "help": "List of development status allowed in manifest file, separated by a comma.",
             },
         ),
         (
-            "external_request_timeout_methods",
+            "external-request-timeout-methods",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
@@ -408,25 +408,25 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             },
         ),
         (
-            "license_allowed",
+            "license-allowed",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
                 "default": DFTL_LICENSE_ALLOWED,
-                "help": "List of license allowed in manifest file, " + "separated by a comma.",
+                "help": "List of license allowed in manifest file, separated by a comma.",
             },
         ),
         (
-            "manifest_deprecated_keys",
+            "manifest-deprecated-keys",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
                 "default": DFTL_MANIFEST_DEPRECATED_KEYS,
-                "help": "List of keys deprecated in manifest file, " + "separated by a comma.",
+                "help": "List of keys deprecated in manifest file, separated by a comma.",
             },
         ),
         (
-            "manifest_required_authors",
+            "manifest-required-authors",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
@@ -435,16 +435,16 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             },
         ),
         (
-            "manifest_required_keys",
+            "manifest-required-keys",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
                 "default": DFTL_MANIFEST_REQUIRED_KEYS,
-                "help": "List of keys required in manifest file, " + "separated by a comma.",
+                "help": "List of keys required in manifest file, separated by a comma.",
             },
         ),
         (
-            "manifest_version_format",
+            "manifest-version-format",
             {
                 "type": "string",
                 "metavar": "<string>",
@@ -455,16 +455,16 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             },
         ),
         (
-            "method_required_super",
+            "method-required-super",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
                 "default": DFTL_METHOD_REQUIRED_SUPER,
-                "help": "List of methods where call to `super` is required." + "separated by a comma.",
+                "help": "List of methods where call to `super` is required.separated by a comma.",
             },
         ),
         (
-            "no_missing_return",
+            "no-missing-return",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
@@ -473,7 +473,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             },
         ),
         (
-            "odoo_exceptions",
+            "odoo-exceptions",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",
@@ -482,7 +482,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             },
         ),
         (
-            "readme_template_url",
+            "readme-template-url",
             {
                 "type": "string",
                 "metavar": "<string>",
@@ -491,7 +491,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             },
         ),
         (
-            "valid_odoo_versions",
+            "valid-odoo-versions",
             {
                 "type": "csv",
                 "metavar": "<comma separated values>",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -125,7 +125,7 @@ class MainTest(unittest.TestCase):
             "translation-too-many-args",
             "translation-unsupported-format",
         }
-        self.default_extra_params += ["--valid_odoo_versions=13.0"]
+        self.default_extra_params += ["--valid-odoo-versions=13.0"]
         pylint_res = self.run_pylint(self.paths_modules)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors = self.expected_errors.copy()
@@ -136,7 +136,7 @@ class MainTest(unittest.TestCase):
 
     def test_35_checks_emiting_by_odoo_version(self):
         """All odoolint errors vs found but see if were not excluded for valid odoo version"""
-        self.default_extra_params += ["--valid_odoo_versions=14.0"]
+        self.default_extra_params += ["--valid-odoo-versions=14.0"]
         pylint_res = self.run_pylint(self.paths_modules)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors = self.expected_errors.copy()
@@ -149,10 +149,10 @@ class MainTest(unittest.TestCase):
         self.assertEqual(expected_errors, real_errors)
 
     def test_85_valid_odoo_version_format(self):
-        """Test --manifest_version_format parameter"""
+        """Test --manifest-version-format parameter"""
         # First, run Pylint for version 8.0
         extra_params = [
-            r'--manifest_version_format="8\.0\.\d+\.\d+.\d+$"' '--valid_odoo_versions=""',
+            r'--manifest-version-format="8\.0\.\d+\.\d+.\d+$"' '--valid-odoo-versions=""',
             "--disable=all",
             "--enable=manifest-version-format",
         ]
@@ -164,7 +164,7 @@ class MainTest(unittest.TestCase):
         self.assertDictEqual(real_errors, expected_errors)
 
         # Now for version 11.0
-        extra_params[0] = r'--manifest_version_format="11\.0\.\d+\.\d+.\d+$"'
+        extra_params[0] = r'--manifest-version-format="11\.0\.\d+\.\d+.\d+$"'
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
@@ -173,10 +173,10 @@ class MainTest(unittest.TestCase):
         self.assertDictEqual(real_errors, expected_errors)
 
     def test_90_valid_odoo_versions(self):
-        """Test --valid_odoo_versions parameter when it's '8.0' & '11.0'"""
+        """Test --valid-odoo-versions parameter when it's '8.0' & '11.0'"""
         # First, run Pylint for version 8.0
         extra_params = [
-            "--valid_odoo_versions=8.0",
+            "--valid-odoo-versions=8.0",
             "--disable=all",
             "--enable=manifest-version-format",
         ]
@@ -188,7 +188,7 @@ class MainTest(unittest.TestCase):
         self.assertDictEqual(real_errors, expected_errors)
 
         # Now for version 11.0
-        extra_params[0] = "--valid_odoo_versions=11.0"
+        extra_params[0] = "--valid-odoo-versions=11.0"
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
@@ -197,12 +197,12 @@ class MainTest(unittest.TestCase):
         self.assertDictEqual(real_errors, expected_errors)
 
     def test_110_manifest_required_authors(self):
-        """Test --manifest_required_authors using a different author and
+        """Test --manifest-required-authors using a different author and
         multiple authors separated by commas
         """
         # First, run Pylint using a different author
         extra_params = [
-            "--manifest_required_authors=Vauxoo",
+            "--manifest-required-authors=Vauxoo",
             "--disable=all",
             "--enable=manifest-required-author",
         ]
@@ -214,14 +214,14 @@ class MainTest(unittest.TestCase):
         self.assertDictEqual(real_errors, expected_errors)
 
         # Then, run it using multiple authors
-        extra_params[0] = "--manifest_required_authors=Vauxoo,Other"
+        extra_params[0] = "--manifest-required-authors=Vauxoo,Other"
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors["manifest-required-author"] = 3
         self.assertDictEqual(real_errors, expected_errors)
 
         # Testing deprecated attribute
-        extra_params[0] = "--manifest_required_author=" "Odoo Community Association (OCA)"
+        extra_params[0] = "--manifest-required-author=" "Odoo Community Association (OCA)"
         pylint_res = self.run_pylint(self.paths_modules, extra_params)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors_deprecated = {


### PR DESCRIPTION
The standard for options is using "-" to be used from cli parameters

even if the configuration file is used with underscore