### PR TITLE
[FIX] pylint_odoo: "ImportError: No module named 'packaging'"

### DIFF
--- a/src/pylint_odoo/checkers/odoo_base_checker.py
+++ b/src/pylint_odoo/checkers/odoo_base_checker.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pylint
-from packaging import version
 from pylint.checkers import BaseChecker
 
 from .. import misc
@@ -34,7 +33,11 @@ class OdooBaseChecker(BaseChecker):
         required_odoo_versions = self.checks_maxmin_odoo_version.get(msg_symbol) or {}
         odoo_minversion = required_odoo_versions.get("odoo_minversion") or misc.DFTL_VALID_ODOO_VERSIONS[0]
         odoo_maxversion = required_odoo_versions.get("odoo_maxversion") or misc.DFTL_VALID_ODOO_VERSIONS[-1]
-        return version.parse(odoo_minversion) <= version.parse(odoo_version) <= version.parse(odoo_maxversion)
+        return (
+            misc.version_parse(odoo_minversion)
+            <= misc.version_parse(odoo_version)
+            <= misc.version_parse(odoo_maxversion)
+        )
 
     def add_message(self, msgid, *args, **kwargs):
         """Emit translation-not-lazy instead of logging-not-lazy"""

--- a/src/pylint_odoo/misc.py
+++ b/src/pylint_odoo/misc.py
@@ -39,6 +39,10 @@ class StringParseError(TypeError):
     pass
 
 
+def version_parse(version_str):
+    return tuple(map(int, version_str.split(".")))
+
+
 def get_plugin_msgs(pylint_run_res):
     """Get all message of this pylint plugin.
     :param pylint_run_res: Object returned by pylint.run method.


### PR DESCRIPTION
It is not a built-in package for py3.10

In fact, it requires install this extra package

Better removing this extra requirement


NOTE: The weird part is that the tox environment is not raising the error, maybe the test-requirements is installing it