### PR TITLE
[FIX] custom_logging: Fix AstroidSyntaxError using only binop related to '%'

### DIFF
--- a/src/pylint_odoo/checkers/custom_logging.py
+++ b/src/pylint_odoo/checkers/custom_logging.py
@@ -86,7 +86,7 @@ class CustomLoggingChecker(OdooBaseChecker, logging.LoggingChecker):
         return new_node
 
     def visit_binop(self, node):
-        if not isinstance(node.left, nodes.Call):
+        if not isinstance(node.left, nodes.Call) or node.op != "%":
             return
         self.visit_call(self.transform_binop2call(node))
 


### PR DESCRIPTION
binop are related to `-`, `+`, `%` but we are using only `%` to parse strings