### PR TITLE
[REF] no-wizard-in-models: Add exception for "res.config*" inherited classes

### DIFF
--- a/testing/resources/test_repo/broken_module/models/broken_model.py
+++ b/testing/resources/test_repo/broken_module/models/broken_model.py
@@ -807,6 +807,18 @@ class TestModel3(
     pass
 
 
+class TestModel4(
+    odoo.models.TransientModel):
+    # Valid no-wizard-in-model
+    _inherit = "res.config.settings"
+
+
+class TestModel5(
+    odoo.models.TransientModel):  # pylint: disable=no-wizard-in-models
+    # Valid no-wizard-in-model
+    _inherit = "my.transient.model"
+
+
 class NoOdoo(object):
     length = 0
 


### PR DESCRIPTION
Odoo is using TrasientModels for "res.config*" inherited classes from models directory