### PR TITLE
[FIX] Exclude missing-return checks for computed methods

### DIFF
--- a/testing/resources/test_repo/test_module/missing-return-compute.py
+++ b/testing/resources/test_repo/test_module/missing-return-compute.py
@@ -1,0 +1,16 @@
+# 'missing-return' not necessary inside compute methods, even if super is called
+# we can only make sure the method is used to compute fields if said fields/methods
+# are declared in the same python module (file)
+from odoo import api, fields, models
+
+
+class MissingReturnCompute(models.Model):
+
+    discount = fields.Float(compute="_compute_discount", store=True)
+
+    @api.depends("order_id", "order_id.general_discount")
+    def _compute_discount(self):
+        if hasattr(super(), "_compute_discount"):
+            super()._compute_discount()
+        for line in self:
+            line.discount = line.order_id.general_discount


### PR DESCRIPTION
Fixes #450. Compute methods are not supposed to return any value, even if there is a super() in it, since super() shouldn't return anything either.

The only reliable way to ensure a field is computed is if has been declared in the same python module (file), so this exclusion only applies to a limited set of cases.