### PR TITLE
[FIX] pre-commit-vauxoo: Fix isort hook - RuntimeError The Poetry configuration is invalid

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort except __init__.py


### PR DESCRIPTION
Fixing the following traceback for a new environment:

`python3.10 -m tox -e lint`

    lint: commands[0]> pre-commit run --all-files --show-diff-on-failure --color=always
    [INFO] Installing environment for https://github.com/PyCQA/isort.
    [INFO] Once installed this environment will be reused.
    [INFO] This may take a few minutes...
    An unexpected error has occurred: CalledProcessError: command: ('~/.cache/pre-commit/repotkw2xyso/py_env-python3/bin/python', '-mpip', 'install', '.')
    return code: 1
    stdout:
        Processing ~/.cache/pre-commit/repotkw2xyso
        Installing build dependencies: started
        Installing build dependencies: finished with status 'done'
        Getting requirements to build wheel: started
        Getting requirements to build wheel: finished with status 'done'
        Preparing metadata (pyproject.toml): started
        Preparing metadata (pyproject.toml): finished with status 'error'

    stderr:
        error: subprocess-exited-with-error

        × Preparing metadata (pyproject.toml) did not run successfully.
        │ exit code: 1
        ╰─> [14 lines of output]
            Traceback (most recent call last):
                File "~/.cache/pre-commit/repotkw2xyso/py_env-python3/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
                main()
                File "~/.cache/pre-commit/repotkw2xyso/py_env-python3/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
                json_out['return_val'] = hook(**hook_input['kwargs'])
                File "~/.cache/pre-commit/repotkw2xyso/py_env-python3/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
                return hook(metadata_directory, config_settings)
                File "/private/var/folders/4r/jsj0bs210jbd57v0zbfk5xx40000gn/T/pip-build-env-dgcj3jmu/overlay/lib/python3.10/site-packages/poetry/core/masonry/api.py", line 40, in prepare_metadata_for_build_wheel
                poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
                File "/private/var/folders/4r/jsj0bs210jbd57v0zbfk5xx40000gn/T/pip-build-env-dgcj3jmu/overlay/lib/python3.10/site-packages/poetry/core/factory.py", line 57, in create_poetry
                raise RuntimeError("The Poetry configuration is invalid:\n" + message)
            RuntimeError: The Poetry configuration is invalid:
                - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'

            [end of output]

        note: This error originates from a subprocess, and is likely not a problem with pip.
        error: metadata-generation-failed

        × Encountered error while generating package metadata.
        ╰─> See above for output.

        note: This is an issue with the package mentioned above, not pip.
        hint: See above for details.

<img width="1389" alt="Screenshot 2023-02-20 at 13 51 08" src="https://user-images.githubusercontent.com/6644187/220188462-e35566a2-9ebd-4d82-a2af-ff0c4bb04c15.png">

