### PR TITLE
[REF] tox: Build ChangeLog again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,10 +43,7 @@ commands =
 [testenv:build]
 skip_install = true
 deps =
-    build
-    bump2version
-    twine
-    wheel
+    {[testenv]deps}
 commands =
     python -m build --sdist --wheel --outdir dist_wo_pbr/
     python -c "import shutil;shutil.rmtree('dist/', ignore_errors=True)"


### PR DESCRIPTION
ChangeLog requires 'pbr'

But since this build was migrated to tox the dependencies were not installed correctly

```diff
- ChangeLog was not generated. You need to install "pbr"
+ 1.0.0 ... # all versions info
```
