### PR TITLE
[REF] Filter out "bump version" from CHANGELOG

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,11 @@ def generate_changelog():
         with open(fname, "w", encoding="UTF-8") as fchg:
             fchg.write(changelog_str)
         return changelog_str
+
     changelog = git._iter_log_oneline()
     changelog = git._iter_changelog(changelog)
-    git.write_git_changelog(changelog=changelog)
-    # git.generate_authors()
+    git.write_git_changelog(changelog=filter(lambda log: not log[1].startswith("* Bump version"), changelog))
+
     return read(fname)
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,9 @@ def generate_changelog():
         with open(fname, "w", encoding="UTF-8") as fchg:
             fchg.write(changelog_str)
         return changelog_str
-
     changelog = git._iter_log_oneline()
     changelog = git._iter_changelog(changelog)
     git.write_git_changelog(changelog=filter(lambda log: not log[1].startswith("* Bump version"), changelog))
-
     return read(fname)
 
 


### PR DESCRIPTION
Commits which bump versions will no longer be displayed on the auto generated CHANGELOG.

Closes #471.