### PR TITLE
[REF]: update to pylint 3.0.0, drop support for py3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest, macos-latest]
         tox_env: [py]
         include:
@@ -28,9 +28,6 @@ jobs:
           - python: '3.10'
             os: ubuntu-latest
             tox_env: 'build'
-        exclude:
-          - python: '3.7'
-            os: windows-latest
     steps:
     - name: Set git to not change EoL
       if: runner.os == 'Windows'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pylint-plugin-utils==0.7
-pylint==2.15.*
+pylint>=3, <4
 validators==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pylint-plugin-utils==0.7
-pylint>=3, <4
+pylint=3.0.*
 validators==0.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ summary = Pylint plugin for Odoo
 long_description_content_type = text/markdown
 license = APGL3
 home_page = https://github.com/OCA/pylint-odoo
-requires_python = >=3.7.2
+requires_python = >=3.8
 classifier =
     Development Status :: 6 - Mature
     Environment :: Console
@@ -18,7 +18,6 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -1386,7 +1386,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
         return tuple(args) or kwargs
 
     @utils.only_required_for_messages("except-pass")
-    def visit_tryexcept(self, node):
+    def visit_try(self, node):
         """Visit block try except"""
         for handler in node.handlers:
             if not handler.name and len(handler.body) == 1 and isinstance(handler.body[0], nodes.node_classes.Pass):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -281,7 +281,6 @@ class MainTest(unittest.TestCase):
         pylint_res = self.run_pylint(path_modules, extra_params)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
-            "invalid-name": 1,
             "unused-argument": 1,
         }
         self.assertDictEqual(real_errors, expected_errors)
@@ -291,7 +290,7 @@ class MainTest(unittest.TestCase):
         pylint_res = self.run_pylint(path_modules, extra_params)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
-            "invalid-name": 3,
+            "invalid-name": 1,
             "unused-argument": 2,
         }
         self.assertDictEqual(real_errors, expected_errors)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist =
     lint,
     update-readme,
     build,
-    py37,
     py38,
     py39,
     py310,


### PR DESCRIPTION
Pylint 3.0.0 has been released and with it a bunch of fixes and improvements. This repository has been updated to depend on this new version.

BREAKING CHANGE: Pylint 3.0.0 drops support for Python 3.7 so this plugin no longer supports Python 3.7 as well.

Closes #473.