### PR TITLE
[IMP] misc.py: add 17.0 as a valid odoo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ Checks valid only for odoo <= 13.0
 
  * manifest-version-format
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.0.1/testing/resources/test_repo/broken_module/__openerp__.py#L8 Wrong Version Format "8_0.1.0.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0)\.\d+\.\d+\.\d+$"
-    - https://github.com/OCA/pylint-odoo/blob/v9.0.1/testing/resources/test_repo/broken_module2/__openerp__.py#L8 Wrong Version Format "1.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0)\.\d+\.\d+\.\d+$"
-    - https://github.com/OCA/pylint-odoo/blob/v9.0.1/testing/resources/test_repo/broken_module3/__openerp__.py#L8 Wrong Version Format "8.0.1.0.0foo" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0)\.\d+\.\d+\.\d+$"
+    - https://github.com/OCA/pylint-odoo/blob/v9.0.1/testing/resources/test_repo/broken_module/__openerp__.py#L8 Wrong Version Format "8_0.1.0.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0)\.\d+\.\d+\.\d+$"
+    - https://github.com/OCA/pylint-odoo/blob/v9.0.1/testing/resources/test_repo/broken_module2/__openerp__.py#L8 Wrong Version Format "1.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0)\.\d+\.\d+\.\d+$"
+    - https://github.com/OCA/pylint-odoo/blob/v9.0.1/testing/resources/test_repo/broken_module3/__openerp__.py#L8 Wrong Version Format "8.0.1.0.0foo" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0)\.\d+\.\d+\.\d+$"
 
  * method-compute
 

--- a/src/pylint_odoo/misc.py
+++ b/src/pylint_odoo/misc.py
@@ -31,6 +31,7 @@ DFTL_VALID_ODOO_VERSIONS = [
     "14.0",
     "15.0",
     "16.0",
+    "17.0",
 ]
 DFTL_MANIFEST_VERSION_FORMAT = r"({valid_odoo_versions})\.\d+\.\d+\.\d+$"
 


### PR DESCRIPTION
Odoo 17 was recently released and therefore said version it has been added to DFTL_VALID_ODOO_VERSIONS.

Fixes #476.