### PR TITLE
[FIX] odoo-addons-relative-import: exclude migrations

### DIFF
--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -1488,6 +1488,9 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
 
     def check_odoo_relative_import(self, node):
         node_dirpath = os.path.dirname(node.root().file)
+        if os.path.basename(os.path.dirname(node_dirpath)) == "migrations":
+            return
+
         manifest_path = misc.walk_up(node_dirpath, tuple(misc.MANIFEST_FILES), misc.top_path(node_dirpath))
         if not manifest_path:
             return

--- a/testing/resources/test_repo/test_module/migrations/10.0.1.0.0/pre-migration.py
+++ b/testing/resources/test_repo/test_module/migrations/10.0.1.0.0/pre-migration.py
@@ -1,4 +1,5 @@
 from odoo import SUPERUSER_ID, api
+from odoo.addons.test_module import random_stuff
 
 
 def method(cr, unused):


### PR DESCRIPTION
Since migration files don't have an __init__,py, they can't perform relative imports, leaving absolute imports as the only option. Therefore this message does not apply to them.

Fixes #480.