### PR TITLE
[ADD] prohibited-method-override: Add a new check to identify methods marked as prohibited to override

### DIFF
--- a/testing/resources/test_repo/broken_module/tests/test_model.py
+++ b/testing/resources/test_repo/broken_module/tests/test_model.py
@@ -11,3 +11,25 @@ class TestModel(TransactionCase):
     def test_1(self):
         self.partner.message_post(body="Test", subtype="mail.mt_comment")
         self.partner.message_post("Test", subtype="mail.mt_comment")
+
+    def test_base_method_1(self):
+        # Override prohibited, should fail
+        super().test_base_method_1()
+        # No override applied, should not fail
+        super().test_base_method_2()
+        return super().test_base_method_3()
+
+    def test_base_method_2(self):
+        # No override applied, should not fail
+        super(TestModel, self).test_base_method_1()
+        # Override allowed, should not fail
+        super(TestModel, self).test_base_method_2()
+        # No override applied, should not fail
+        return super(TestModel, self).test_base_method_3()
+
+    def test_base_method_3(self):
+        # No override applied, should not fail
+        super(TestModel, self).test_base_method_1()
+        super(TestModel, self).test_base_method_2()
+        # Override prohibited, should fail
+        return super(TestModel, self).test_base_method_3()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -410,6 +410,20 @@ def fstring_no_sqli(self):
             pylint_res.linter.stats.by_msg["deprecated-odoo-model-method"],
         )
 
+    def test_175_prohibited_method_override(self):
+        """Test --prohibited_override_methods parameter"""
+        extra_params = [
+            "--disable=all",
+            "--enable=prohibited-method-override",
+            "--prohibited-method-override=test_base_method_1,test_base_method_3",
+        ]
+        pylint_res = self.run_pylint(self.paths_modules, extra_params, verbose=True)
+        real_errors = pylint_res.linter.stats.by_msg
+        expected_errors = {
+            "prohibited-method-override": 2,
+        }
+        self.assertDictEqual(real_errors, expected_errors)
+
     @staticmethod
     def re_replace(sub_start, sub_end, substitution, content):
         re_sub = re.compile(rf"^{re.escape(sub_start)}$.*^{re.escape(sub_end)}$", re.M | re.S)


### PR DESCRIPTION
# Pull Request Template

## Description
- Check for prohibited methods being overridden.
- Enables the user to specify, for example, core Odoo methods that should remain unaltered and cannot be overridden under any circumstances.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. There's a new test named `test_175_prohibited_method_override` within _test_main.py_.
2. Run the command below to start the test (using Python v3.9).
```sh
$ tox -e py39  -- -k test_175_prohibited_method_override
```
3. Verify that the test passes with two methods prohibited from being overridden. ✅ 
```sh
tests/test_main.py::MainTest::test_175_prohibited_method_override ************* Module broken_module.tests.test_model
testing/resources/test_repo/broken_module/tests/test_model.py:15 Prohibited override of "some_base_method_1" method. - [prohibited-method-override]
testing/resources/test_repo/broken_module/tests/test_model.py:15 Prohibited override of "some_base_method_2" method. - [prohibited-method-override]

PASSED
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
