### PR TITLE
[REM] pylint_odoo: Remove requirements/requirements.txt from build

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,6 @@ source = src
 [run]
 source = src
 parallel = true
-dynamic_context = test_function
 context = ${{COVERAGE_CONTEXT}}
 
 [report]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,13 +28,9 @@ classifier =
     Topic :: Software Development :: Testing
 
 [options]
-package_dir=
+package_dir =
     =src
-packages=find:
+packages = find:
 
 [options.packages.find]
-where=src
-
-[options.data_files]
-requirements =
-    requirements.txt
+where = src

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands =
     python -m twine check --strict dist/*
     bump2version patch --allow-dirty --no-commit --no-tag --dry-run --verbose
     # Install packages from binaries to test if all files were already included in the compressed file
-    python -c '''import sys,pip,os,glob;os.chdir("dist");sys.argv = ["", "install", "-U", "--force-reinstall", glob.glob("*.tar.gz")[-1], "--use-feature=no-binary-enable-wheel-cache"];pip.main()'''
+    python -c '''import sys,pip,os,glob;os.chdir("dist");print("Current dir: %s" % os.getcwd());sys.argv = ["", "install", "-U", "--force-reinstall", glob.glob("*.tar.gz")[-1], "--use-feature=no-binary-enable-wheel-cache"];pip.main()'''
     # Testing the package is importing the dependencies well
     python -c '''from pylint.lint import Run;import os;os.chdir("dist");res = Run(["--load-plugins=pylint_odoo", "-c", "non-exists.cfg", "--disable=all", "--enable=odoolint", "--list-msgs-enabled"])'''
 


### PR DESCRIPTION
When installing a wheel the file `<installroot>/requirements/requirements.txt` is created. This appears to have been intentionally introduced to fix #440 by introducing the following lines to `setup.cfg`:
 - https://github.com/OCA/pylint-odoo/blob/6e857c52117ef8597e0433b32ca6fac302ea76b8/setup.cfg#L38-L40

However, this is not the correct format for adding files (they should be an array of `(path, file)` tuples), resulting in a directory called "/requirements" that will contain the file, likely not what we want.

It is unclear to me how source tarballs were being generated before, because requirements.txt should always be included when building with setuptools.

**To Reproduce**

Steps to reproduce the behavior:

```
$ python -m venv venv
$ source venv/bin/activate
$ pip install build installer wheel
…
$ python -m build --wheel
…
$ python -m installer dist/pylint_odoo-9.1.3-py3-none-any.whl
$ ls venv/requirements/
requirements.txt
```

This is especially a problem for downstream OS packagers who will be installing the package to the (virtual) root directory as you won't want your final OS package creating `/requirements`.

**Expected behavior**

No files are installed outside of the normal filesystem.

As far as I can tell this configuration can be removed from setup.cfg entirely. Alternatively, using package data is likely what was actually desired here (though, again, I don't see how it would be necessary in this case, building without this config results in requirements.txt being included for me):

```
[options.package_data]
pylint_odoo =
	requirements.txt
```

Fix https://github.com/OCA/pylint-odoo/issues/498

Credits to @SamWhited 