### PR TITLE
[FIX] pylint_odoo: Fix parsing dictionary from manifest

### DIFF
--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -1029,7 +1029,12 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             node.parent, nodes.Expr
         ):
             return
-        manifest_dict = ast.literal_eval(node.as_string())
+        try:
+            manifest_dict = ast.literal_eval(node.as_string())
+        except ValueError:
+            # There is code that the node is formed but literal_eval raises error
+            # e.g. {"key": "" or ""}
+            return
         manifest_keys_nodes = {
             key_node.value: key_node for key_node, _value in node.items if isinstance(key_node, nodes.Const)
         }

--- a/testing/resources/test_repo/broken_module3/__manifest__.py
+++ b/testing/resources/test_repo/broken_module3/__manifest__.py
@@ -1,0 +1,4 @@
+# Verify a dictionary parsed correctly as node but raising error as literal_eval
+{
+    "key": "" or "",
+}


### PR DESCRIPTION
The following code:
 - `{"key": "" or ""}`

It is parsed correctly the node code

But `ast.literal_eval` shows the following traceback:

```txt
Exception on node <Dict.dict l.3 at 0x10ef6aba0>
Traceback (most recent call last):
  File "pylint/utils/ast_walker.py", line 91, in walk
    callback(astroid)
    ~~~~~~~~^^^^^^^^^
  File "pylint_odoo/checkers/odoo_addons.py", line 1034, in visit_dict
    manifest_dict = ast.literal_eval(node.as_string())
  File "3.13/lib/python3.13/ast.py", line 114, in literal_eval
    return _convert(node_or_string)
  File "3.13/lib/python3.13/ast.py", line 103, in _convert
    return dict(zip(map(_convert, node.keys),
                    map(_convert, node.values)))
  File "3.13/lib/python3.13/ast.py", line 113, in _convert
    return _convert_signed_num(node)
  File "3.13/lib/python3.13/ast.py", line 87, in _convert_signed_num
    return _convert_num(node)
  File "3.13/lib/python3.13/ast.py", line 78, in _convert_num
    _raise_malformed_node(node)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "3.13/lib/python3.13/ast.py", line 75, in _raise_malformed_node
    raise ValueError(msg + f': {node!r}')
ValueError: malformed node or string on line 1: <ast.BoolOp object at 0x1104df790>
````