### PR TITLE
[REF] website-manifest-key-not-valid-uri,manifest-behind-migrations: Remove dependencies to extra packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ translation-too-few-args | Not enough arguments for odoo._ format string | E8306
 translation-too-many-args | Too many arguments for odoo._ format string | E8305
 translation-unsupported-format | Unsupported odoo._ format character %r (%#02x) at index %d | E8300
 use-vim-comment | Use of vim comment | W8202
-website-manifest-key-not-valid-uri | Website "%s" in manifest key is not a valid URI | W8114
+website-manifest-key-not-valid-uri | Website "%s" in manifest key is not a valid URI. %s | W8114
 
 
 [//]: # (end-checks)
@@ -394,7 +394,8 @@ Checks valid only for odoo <= 13.0
 
  * website-manifest-key-not-valid-uri
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.1/testing/resources/test_repo/broken_module3/__openerp__.py#L7 Website "htt://odoo-community.com" in manifest key is not a valid URI
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.1/testing/resources/test_repo/broken_module2/__openerp__.py#L7 Website "https://odoo-community.org,https://odoo.com" in manifest key is not a valid URI. Domain 'odoo-community.org,https:' contains invalid characters
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.1/testing/resources/test_repo/broken_module3/__openerp__.py#L7 Website "htt://odoo-community.com" in manifest key is not a valid URI. URL needs to start with 'http[s]://'
 
 [//]: # (end-example)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pylint-plugin-utils==0.8.*
 pylint==3.3.*
-validators==0.34.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-packaging==24.2.*
 pylint-plugin-utils==0.8.*
 pylint==3.3.*
 validators==0.34.*

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -104,7 +104,6 @@ import re
 import string
 from collections import Counter, defaultdict
 
-import packaging.version
 import validators
 from astroid import ClassDef, FunctionDef, NodeNG, nodes
 from pylint.checkers import BaseChecker, utils
@@ -1118,14 +1117,14 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
                 if not os.path.isdir(os.path.join(migrations_path, migration_path)):
                     continue
                 try:
-                    migration_path_v = packaging.version.Version(migration_path)
-                    version_format_v = packaging.version.Version(version_format)
+                    migration_path_v = misc.version2tuple(migration_path)
+                    version_format_v = misc.version2tuple(version_format)
                     if migration_path_v > version_format_v:
                         self.add_message(
                             "manifest-behind-migrations", node=node, args=(version_format, migration_path)
                         )
                         break
-                except packaging.version.InvalidVersion:
+                except misc.InvalidVersion:
                     continue
 
         # Check if resource exist

--- a/src/pylint_odoo/misc.py
+++ b/src/pylint_odoo/misc.py
@@ -1,9 +1,11 @@
 import os
+import re
 import subprocess
 import sys
 from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
+from urllib.parse import urlsplit
 
 MANIFEST_DATA_KEYS = ["data", "demo", "demo_xml", "init_xml", "test", "update_xml"]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -65,7 +65,7 @@ EXPECTED_ERRORS = {
     "translation-too-many-args": 2,
     "translation-unsupported-format": 2,
     "use-vim-comment": 1,
-    "website-manifest-key-not-valid-uri": 1,
+    "website-manifest-key-not-valid-uri": 2,
     "no-raise-unlink": 2,
     "deprecated-odoo-model-method": 2,
     "manifest-behind-migrations": 3,


### PR DESCRIPTION
[REF] website-manifest-key-not-valid-uri: Remove dependency to validators
Adding the same regex to validate URL

[REF] manifest-behind-migrations: Transform version to tuple without packaging library
Reduce the requirements because it is a simple code sustitution
