### PR TITLE
[FIX] manifest-version-format: Catch ValueError exception for valid-odoo-versions parameter

### DIFF
--- a/src/pylint_odoo/checkers/odoo_base_checker.py
+++ b/src/pylint_odoo/checkers/odoo_base_checker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import pylint
 from pylint.checkers import BaseChecker
 
@@ -30,6 +32,15 @@ class OdooBaseChecker(BaseChecker):
         if msg_symbol is None:
             return True
         odoo_version = valid_odoo_versions[0]
+        odoo_version_tuple = misc.version_parse(odoo_version)
+        if not odoo_version_tuple:
+            warnings.warn(
+                f"Invalid manifest versions format {odoo_version}. "
+                "It was not possible to supress checks based on particular odoo version",
+                UserWarning,
+                stacklevel=2,
+            )
+            return True
         required_odoo_versions = self.checks_maxmin_odoo_version.get(msg_symbol) or {}
         odoo_minversion = required_odoo_versions.get("odoo_minversion") or misc.DFTL_VALID_ODOO_VERSIONS[0]
         odoo_maxversion = required_odoo_versions.get("odoo_maxversion") or misc.DFTL_VALID_ODOO_VERSIONS[-1]

--- a/src/pylint_odoo/misc.py
+++ b/src/pylint_odoo/misc.py
@@ -45,7 +45,10 @@ class StringParseError(TypeError):
 
 
 def version_parse(version_str):
-    return tuple(map(int, version_str.split(".")))
+    try:
+        return tuple(map(int, version_str.split(".")))
+    except (ValueError, TypeError):
+        return tuple()
 
 
 def get_plugin_msgs(pylint_run_res):


### PR DESCRIPTION
If you use `--valid-odoo-versions="10.A"` notice there is not digit value

It will raise exceptions errors not watched

This commits catchs the errors
