### PR TITLE
[ADD] deprecated-name-get: name_get deprecated since v17

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ invalid-commit | Use of cr.commit() directly - More info https://github.com/OCA/
 license-allowed | License "%s" not allowed in manifest file. | C8105
 manifest-author-string | The author key in the manifest file must be a string (with comma separated values) | E8101
 manifest-behind-migrations | Manifest version (%s) is lower than migration scripts (%s) | E8145
+deprecated-name-get | 'name_get' is deprecated. Use '_compute_display_name' instead. More info at https://github.com/odoo/odoo/pull/122085. | E8146
 manifest-data-duplicated | The file "%s" is duplicated in lines %s from manifest key "%s" | W8125
 manifest-deprecated-key | Deprecated key "%s" in manifest file | C8103
 manifest-external-assets | Asset %s should be distributed with module's source code. More info at https://httptoolkit.com/blog/public-cdn-risks/ | W8162

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -190,6 +190,11 @@ ODOO_MSGS = {
         "manifest-behind-migrations",
         "Update your manifest version, otherwise the migration script won't run",
     ),
+    "E8146": (
+        "'name_get' is deprecated. Use '_compute_display_name' instead. More info at https://github.com/odoo/odoo/pull/122085.",
+        "deprecated-name-get",
+        CHECK_DESCRIPTION,
+    ),
     "F8101": ('File "%s": "%s" not found.', "resource-not-exist", CHECK_DESCRIPTION),
     "R8101": (
         "`odoo.exceptions.Warning` is a deprecated alias to `odoo.exceptions.UserError` "
@@ -580,6 +585,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
         },
         "no-raise-unlink": {"odoo_minversion": "15.0"},
         "prefer-env-translation": {"odoo_minversion": "18.0"},
+        "deprecated-name-get": {"odoo_minversion": "17.0"},
     }
 
     def __init__(self, linter: PyLinter):
@@ -1244,7 +1250,11 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
         return node.name in self._deprecated_odoo_methods
 
     @utils.only_required_for_messages(
-        "method-required-super", "prohibited-method-override", "missing-return", "deprecated-odoo-model-method"
+        "method-required-super",
+        "prohibited-method-override",
+        "missing-return",
+        "deprecated-odoo-model-method",
+        "deprecated-name-get",
     )
     def visit_functiondef(self, node):
         """Check that `api.one` and `api.multi` decorators not exists together
@@ -1256,7 +1266,8 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
 
         if self.is_odoo_message_enabled("deprecated-odoo-model-method") and self.check_deprecated_odoo_method(node):
             self.add_message("deprecated-odoo-model-method", node=node, args=(node.name,))
-
+        if self.is_odoo_message_enabled("deprecated-name-get") and node.name == "name_get":
+            self.add_message("deprecated-name-get", node=node)
         if node.name in self.linter.config.method_required_super:
             calls = [
                 call_func.func.name

--- a/testing/resources/test_repo/twelve_module/models.py
+++ b/testing/resources/test_repo/twelve_module/models.py
@@ -2,4 +2,8 @@ from odoo import models
 
 
 class TwelveModel(models.Model):
-    _name = 'twelve.model'
+    _name = "twelve.model"
+
+    def name_get(self):
+        # do staff
+        return super().name_get()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,6 +24,7 @@ EXPECTED_ERRORS = {
     "bad-builtin-groupby": 2,
     "consider-merging-classes-inherited": 2,
     "context-overridden": 3,
+    "deprecated-name-get": 1,
     "development-status-allowed": 1,
     "except-pass": 3,
     "external-request-timeout": 51,
@@ -159,6 +160,7 @@ class MainTest(unittest.TestCase):
             "translation-too-few-args",
             "translation-too-many-args",
             "translation-unsupported-format",
+            "deprecated-name-get",
         }
         self.default_extra_params += ["--valid-odoo-versions=13.0"]
         pylint_res = self.run_pylint(self.paths_modules)
@@ -177,6 +179,7 @@ class MainTest(unittest.TestCase):
         expected_errors = self.expected_errors.copy()
         expected_errors.update({"manifest-version-format": 6})
         excluded_msgs = {
+            "deprecated-name-get",
             "deprecated-odoo-model-method",
             "no-raise-unlink",
             "prefer-env-translation",


### PR DESCRIPTION
'name_get' is deprecated since v17. More info at https://github.com/odoo/odoo/pull/122085.