### PR TITLE
[ADD] string-method-name: Add string-method-name check to preserve inheritability

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ prohibited-method-override | Prohibited override of "%s" method. | W8107
 renamed-field-parameter | Field parameter "%s" is no longer supported. Use "%s" instead. | W8111
 resource-not-exist | File "%s": "%s" not found. | F8101
 sql-injection | SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection | E8103
+string-method-name | Use string method name `"%s"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126 | E8147
 test-folder-imported | Test folder imported in module %s | E8130
 translation-contains-variable | Translatable term in "%s" contains variables. Use %s instead | W8115
 translation-field | Translation method _("string") in fields is not necessary. | W8103
@@ -157,9 +158,9 @@ Checks valid only for odoo <= 13.0
 
  * attribute-string-redundant
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L164 The attribute string is redundant. String parameter equal to name of variable
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L212 The attribute string is redundant. String parameter equal to name of variable
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L222 The attribute string is redundant. String parameter equal to name of variable
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L176 The attribute string is redundant. String parameter equal to name of variable
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L224 The attribute string is redundant. String parameter equal to name of variable
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L234 The attribute string is redundant. String parameter equal to name of variable
 
  * bad-builtin-groupby
 
@@ -173,9 +174,9 @@ Checks valid only for odoo <= 13.0
 
  * context-overridden
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L195 Context overridden using dict. Better using kwargs `with_context(**{'overwrite_context': True})` or `with_context(key=value)`
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L197 Context overridden using dict. Better using kwargs `with_context(**ctx)` or `with_context(key=value)`
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L199 Context overridden using dict. Better using kwargs `with_context(**ctx2)` or `with_context(key=value)`
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L207 Context overridden using dict. Better using kwargs `with_context(**{'overwrite_context': True})` or `with_context(key=value)`
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L209 Context overridden using dict. Better using kwargs `with_context(**ctx)` or `with_context(key=value)`
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L211 Context overridden using dict. Better using kwargs `with_context(**ctx2)` or `with_context(key=value)`
 
  * deprecated-name-get
 
@@ -198,15 +199,15 @@ Checks valid only for odoo <= 13.0
 
  * external-request-timeout
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L1001 Use of external request method `odoo.addons.iap.models.iap.jsonrpc` without timeout. It could wait for a long time
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L1002 Use of external request method `odoo.addons.iap.models.iap.jsonrpc` without timeout. It could wait for a long time
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L1003 Use of external request method `odoo.addons.iap.models.iap.jsonrpc` without timeout. It could wait for a long time
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L1001 Use of external request method `serial.Serial` without timeout. It could wait for a long time
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L1002 Use of external request method `serial.Serial` without timeout. It could wait for a long time
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L1003 Use of external request method `serial.Serial` without timeout. It could wait for a long time
 
  * invalid-commit
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L540 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L541 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L542 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L552 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L553 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L554 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
 
  * license-allowed
 
@@ -256,11 +257,11 @@ Checks valid only for odoo <= 13.0
 
  * method-compute
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L158 Name of compute method should start with "_compute_"
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L170 Name of compute method should start with "_compute_"
 
  * method-inverse
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L160 Name of inverse method should start with "_inverse_"
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L172 Name of inverse method should start with "_inverse_"
 
  * method-required-super
 
@@ -270,7 +271,7 @@ Checks valid only for odoo <= 13.0
 
  * method-search
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L159 Name of search method should start with "_search_"
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L171 Name of search method should start with "_search_"
 
  * missing-readme
 
@@ -287,7 +288,7 @@ Checks valid only for odoo <= 13.0
 
  * no-wizard-in-models
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L1024 No wizard class for model directory. See the complete structure https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#complete-structure
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L1036 No wizard class for model directory. See the complete structure https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#complete-structure
 
  * no-write-in-compute
 
@@ -309,9 +310,9 @@ Checks valid only for odoo <= 13.0
 
  * prefer-env-translation
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L146 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L156 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L322 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L152 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L168 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L334 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
 
  * print-used
 
@@ -319,8 +320,8 @@ Checks valid only for odoo <= 13.0
 
  * renamed-field-parameter
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L212 Field parameter "digits_compute" is no longer supported. Use "digits" instead.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L212 Field parameter "select" is no longer supported. Use "index" instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L224 Field parameter "digits_compute" is no longer supported. Use "digits" instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L224 Field parameter "select" is no longer supported. Use "index" instead.
 
  * resource-not-exist
 
@@ -330,9 +331,15 @@ Checks valid only for odoo <= 13.0
 
  * sql-injection
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L771 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L773 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L775 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L783 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L785 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L787 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
+
+ * string-method-name
+
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L161 Use string method name `"_compute_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L162 Use string method name `"_search_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L163 Use string method name `"_inverse_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
 
  * test-folder-imported
 
@@ -342,63 +349,63 @@ Checks valid only for odoo <= 13.0
 
  * translation-contains-variable
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L374 Translatable term in "'Variable not translatable: %s' % variable1" contains variables. Use _('Variable not translatable: %s') % variable1 instead
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L375 Translatable term in "'Variables not translatable: %s, %s' % (variable1, variable2)" contains variables. Use _('Variables not translatable: %s, %s') % (variable1, variable2) instead
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L377 Translatable term in "'Variable not translatable: %s' % variable1" contains variables. Use _('Variable not translatable: %s') % variable1 instead
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L386 Translatable term in "'Variable not translatable: %s' % variable1" contains variables. Use _('Variable not translatable: %s') % variable1 instead
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L387 Translatable term in "'Variables not translatable: %s, %s' % (variable1, variable2)" contains variables. Use _('Variables not translatable: %s, %s') % (variable1, variable2) instead
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L389 Translatable term in "'Variable not translatable: %s' % variable1" contains variables. Use _('Variable not translatable: %s') % variable1 instead
 
  * translation-field
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L146 Translation method _("string") in fields is not necessary.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L156 Translation method _("string") in fields is not necessary.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L152 Translation method _("string") in fields is not necessary.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L168 Translation method _("string") in fields is not necessary.
 
  * translation-format-interpolation
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L383 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L384 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L447 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L395 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L396 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L459 Use lazy % or .format() or % formatting in odoo._ functions
 
  * translation-format-truncated
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L649 Logging format string ends in middle of conversion specifier
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L664 Logging format string ends in middle of conversion specifier
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L661 Logging format string ends in middle of conversion specifier
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L676 Logging format string ends in middle of conversion specifier
 
  * translation-fstring-interpolation
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L647 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L662 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L659 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L674 Use lazy % or .format() or % formatting in odoo._ functions
 
  * translation-not-lazy
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L348 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L349 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L351 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L360 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L361 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L363 Use lazy % or .format() or % formatting in odoo._ functions
 
  * translation-positional-used
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L375 Translation method _('Variables not translatable: %s, %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L378 Translation method _('Variables not translatable: %s %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L381 Translation method _('Variables not translatable: %s, %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L387 Translation method _('Variables not translatable: %s, %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L390 Translation method _('Variables not translatable: %s %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L393 Translation method _('Variables not translatable: %s, %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
 
  * translation-required
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L325 String parameter on "message_post" requires translation. Use body=_('Body not translatable %s')
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L325 String parameter on "message_post" requires translation. Use subject=_('Subject not translatable')
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L327 String parameter on "message_post" requires translation. Use body=_('Body not translatable {}')
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L337 String parameter on "message_post" requires translation. Use body=_('Body not translatable %s')
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L337 String parameter on "message_post" requires translation. Use subject=_('Subject not translatable')
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L339 String parameter on "message_post" requires translation. Use body=_('Body not translatable {}')
 
  * translation-too-few-args
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L645 Not enough arguments for odoo._ format string
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L660 Not enough arguments for odoo._ format string
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L657 Not enough arguments for odoo._ format string
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L672 Not enough arguments for odoo._ format string
 
  * translation-too-many-args
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L650 Too many arguments for odoo._ format string
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L665 Too many arguments for odoo._ format string
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L662 Too many arguments for odoo._ format string
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L677 Too many arguments for odoo._ format string
 
  * translation-unsupported-format
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L648 Unsupported odoo._ format character 'y' (0x79) at index 30
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L663 Unsupported odoo._ format character 'y' (0x79) at index 30
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L660 Unsupported odoo._ format character 'y' (0x79) at index 30
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.3/testing/resources/test_repo/broken_module/models/broken_model.py#L675 Unsupported odoo._ format character 'y' (0x79) at index 30
 
  * use-vim-comment
 

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -195,6 +195,12 @@ ODOO_MSGS = {
         "deprecated-name-get",
         CHECK_DESCRIPTION,
     ),
+    "E8147": (
+        'Use string method name `"%s"` to preserve inheritability. '
+        "More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126",
+        "string-method-name",
+        CHECK_DESCRIPTION,
+    ),
     "F8101": ('File "%s": "%s" not found.', "resource-not-exist", CHECK_DESCRIPTION),
     "R8101": (
         "`odoo.exceptions.Warning` is a deprecated alias to `odoo.exceptions.UserError` "
@@ -819,6 +825,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
         "print-used",
         "renamed-field-parameter",
         "sql-injection",
+        "string-method-name",
         "translation-contains-variable",
         "translation-field",
         "translation-positional-used",
@@ -895,6 +902,12 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
                         )
                         if method_name and self.class_odoo_models:
                             self.odoo_computes.add(method_name)
+                    if (
+                        self.linter.is_message_enabled("string-method-name", node.lineno)
+                        and argument.arg in ["compute", "search", "inverse"]
+                        and isinstance(argument.value, nodes.Name)
+                    ):
+                        self.add_message("string-method-name", node=argument.value, args=(argument.value.name,))
                 if (
                     isinstance(argument_aux, nodes.Call)
                     and self.get_func_name(argument_aux.func) in misc.TRANSLATION_METHODS

--- a/testing/resources/test_repo/broken_module/models/broken_model.py
+++ b/testing/resources/test_repo/broken_module/models/broken_model.py
@@ -127,6 +127,12 @@ class TestModel(models.Model):
         unknown_type_object.write('write not self.browse allowed')
         self.write({"name": "hello"})  # pylint: disable=no-write-in-compute
 
+    def _search_name(self):
+        pass
+
+    def _inverse_name(self):
+        pass
+
     def _compute_with_method_def(self):
         # Compute called from funct-def with write
         self.write({"name": "hello"})
@@ -149,6 +155,12 @@ class TestModel(models.Model):
         compute='_compute_name',  # good compute method name
         search='_search_name',  # good search method name
         inverse='_inverse_name',  # good inverse method name
+    )
+
+    name2 = fields.Char(
+        compute=_compute_name,  # bad string-method-name
+        search=_search_name,  # bad string-method-name
+        inverse=_inverse_name,  # bad string-method-name
     )
 
     # Imported openerp.fields use Char (Upper case)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,6 +53,7 @@ EXPECTED_ERRORS = {
     "renamed-field-parameter": 2,
     "resource-not-exist": 4,
     "sql-injection": 21,
+    "string-method-name": 4,
     "test-folder-imported": 3,
     "translation-contains-variable": 33,
     "translation-field": 2,


### PR DESCRIPTION
Bad

```python
    name = fields.Char(
        compute=_compute_name,
        search=_search_name,
        inverse=_inverse_name,
    )
```

Good

```python
    name = fields.Char(
        compute="_compute_name",
        search="_search_name",
        inverse="_inverse_name",
    )
```

Fix https://github.com/OCA/odoo-pre-commit-hooks/issues/126