### PR TITLE
[FIX] inheritable-method-*: Consider only methods from classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,20 +153,20 @@ Checks valid only for odoo <= 13.0
 
  * attribute-deprecated
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L124 attribute "_columns" deprecated
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L125 attribute "_defaults" deprecated
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L126 attribute "length" deprecated
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L128 attribute "_columns" deprecated
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L129 attribute "_defaults" deprecated
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L130 attribute "length" deprecated
 
  * attribute-string-redundant
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L192 The attribute string is redundant. String parameter equal to name of variable
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L240 The attribute string is redundant. String parameter equal to name of variable
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L250 The attribute string is redundant. String parameter equal to name of variable
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L196 The attribute string is redundant. String parameter equal to name of variable
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L244 The attribute string is redundant. String parameter equal to name of variable
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L254 The attribute string is redundant. String parameter equal to name of variable
 
  * bad-builtin-groupby
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L129 Used builtin function `itertools.groupby`. Prefer `odoo.tools.groupby` instead. More info about https://github.com/odoo/odoo/issues/105376
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L130 Used builtin function `itertools.groupby`. Prefer `odoo.tools.groupby` instead. More info about https://github.com/odoo/odoo/issues/105376
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L133 Used builtin function `itertools.groupby`. Prefer `odoo.tools.groupby` instead. More info about https://github.com/odoo/odoo/issues/105376
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L134 Used builtin function `itertools.groupby`. Prefer `odoo.tools.groupby` instead. More info about https://github.com/odoo/odoo/issues/105376
 
  * consider-merging-classes-inherited
 
@@ -175,9 +175,9 @@ Checks valid only for odoo <= 13.0
 
  * context-overridden
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L223 Context overridden using dict. Better using kwargs `with_context(**{'overwrite_context': True})` or `with_context(key=value)`
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L225 Context overridden using dict. Better using kwargs `with_context(**ctx)` or `with_context(key=value)`
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L227 Context overridden using dict. Better using kwargs `with_context(**ctx2)` or `with_context(key=value)`
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L227 Context overridden using dict. Better using kwargs `with_context(**{'overwrite_context': True})` or `with_context(key=value)`
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L229 Context overridden using dict. Better using kwargs `with_context(**ctx)` or `with_context(key=value)`
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L231 Context overridden using dict. Better using kwargs `with_context(**ctx2)` or `with_context(key=value)`
 
  * deprecated-name-get
 
@@ -185,7 +185,7 @@ Checks valid only for odoo <= 13.0
 
  * deprecated-odoo-model-method
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L110 fields_view_get has been deprecated by Odoo. Please look for alternatives.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L114 fields_view_get has been deprecated by Odoo. Please look for alternatives.
     - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/eleven_module/models.py#L17 fields_view_get has been deprecated by Odoo. Please look for alternatives.
 
  * development-status-allowed
@@ -200,26 +200,26 @@ Checks valid only for odoo <= 13.0
 
  * external-request-timeout
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L1005 Use of external request method `smtplib.SMTP` without timeout. It could wait for a long time
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L1006 Use of external request method `smtplib.SMTP` without timeout. It could wait for a long time
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L1007 Use of external request method `smtplib.SMTP` without timeout. It could wait for a long time
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L1009 Use of external request method `smtplib.SMTP` without timeout. It could wait for a long time
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L1010 Use of external request method `smtplib.SMTP` without timeout. It could wait for a long time
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L1011 Use of external request method `smtplib.SMTP` without timeout. It could wait for a long time
 
  * inheritable-method-lambda
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L102 Use `default=lambda self: self._default()` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L105 Use `domain=lambda self: self._domain()` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L104 Use `default=lambda self: self._default()` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L107 Use `domain=lambda self: self._domain()` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
 
  * inheritable-method-string
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L177 Use string method name `"_compute_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L178 Use string method name `"_search_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L179 Use string method name `"_inverse_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L181 Use string method name `"_compute_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L182 Use string method name `"_search_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L183 Use string method name `"_inverse_name"` to preserve inheritability. More info at https://github.com/OCA/odoo-pre-commit-hooks/issues/126
 
  * invalid-commit
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L568 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L569 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L570 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L572 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L573 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L574 Use of cr.commit() directly - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#never-commit-the-transaction
 
  * license-allowed
 
@@ -269,11 +269,11 @@ Checks valid only for odoo <= 13.0
 
  * method-compute
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L186 Name of compute method should start with "_compute_"
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L190 Name of compute method should start with "_compute_"
 
  * method-inverse
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L188 Name of inverse method should start with "_inverse_"
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L192 Name of inverse method should start with "_inverse_"
 
  * method-required-super
 
@@ -283,7 +283,7 @@ Checks valid only for odoo <= 13.0
 
  * method-search
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L187 Name of search method should start with "_search_"
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L191 Name of search method should start with "_search_"
 
  * missing-readme
 
@@ -300,13 +300,13 @@ Checks valid only for odoo <= 13.0
 
  * no-wizard-in-models
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L1052 No wizard class for model directory. See the complete structure https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#complete-structure
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L1056 No wizard class for model directory. See the complete structure https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#complete-structure
 
  * no-write-in-compute
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L133 Compute method calling `write`. Use `update` instead.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L135 Compute method calling `write`. Use `update` instead.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L138 Compute method calling `write`. Use `update` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L137 Compute method calling `write`. Use `update` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L139 Compute method calling `write`. Use `update` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L142 Compute method calling `write`. Use `update` instead.
 
  * odoo-addons-relative-import
 
@@ -322,9 +322,9 @@ Checks valid only for odoo <= 13.0
 
  * prefer-env-translation
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L168 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L184 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L350 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L172 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L188 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L354 Better using self.env._ More info at https://github.com/odoo/odoo/pull/174844
 
  * print-used
 
@@ -332,8 +332,8 @@ Checks valid only for odoo <= 13.0
 
  * renamed-field-parameter
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L240 Field parameter "digits_compute" is no longer supported. Use "digits" instead.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L240 Field parameter "select" is no longer supported. Use "index" instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L244 Field parameter "digits_compute" is no longer supported. Use "digits" instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L244 Field parameter "select" is no longer supported. Use "index" instead.
 
  * resource-not-exist
 
@@ -343,9 +343,9 @@ Checks valid only for odoo <= 13.0
 
  * sql-injection
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L799 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L801 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
     - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L803 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L805 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L807 SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#no-sql-injection
 
  * test-folder-imported
 
@@ -355,63 +355,63 @@ Checks valid only for odoo <= 13.0
 
  * translation-contains-variable
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L402 Translatable term in "'Variable not translatable: %s' % variable1" contains variables. Use _('Variable not translatable: %s') % variable1 instead
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L403 Translatable term in "'Variables not translatable: %s, %s' % (variable1, variable2)" contains variables. Use _('Variables not translatable: %s, %s') % (variable1, variable2) instead
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L405 Translatable term in "'Variable not translatable: %s' % variable1" contains variables. Use _('Variable not translatable: %s') % variable1 instead
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L406 Translatable term in "'Variable not translatable: %s' % variable1" contains variables. Use _('Variable not translatable: %s') % variable1 instead
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L407 Translatable term in "'Variables not translatable: %s, %s' % (variable1, variable2)" contains variables. Use _('Variables not translatable: %s, %s') % (variable1, variable2) instead
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L409 Translatable term in "'Variable not translatable: %s' % variable1" contains variables. Use _('Variable not translatable: %s') % variable1 instead
 
  * translation-field
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L168 Translation method _("string") in fields is not necessary.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L184 Translation method _("string") in fields is not necessary.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L172 Translation method _("string") in fields is not necessary.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L188 Translation method _("string") in fields is not necessary.
 
  * translation-format-interpolation
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L411 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L412 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L475 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L415 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L416 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L479 Use lazy % or .format() or % formatting in odoo._ functions
 
  * translation-format-truncated
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L677 Logging format string ends in middle of conversion specifier
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L692 Logging format string ends in middle of conversion specifier
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L681 Logging format string ends in middle of conversion specifier
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L696 Logging format string ends in middle of conversion specifier
 
  * translation-fstring-interpolation
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L675 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L690 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L679 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L694 Use lazy % or .format() or % formatting in odoo._ functions
 
  * translation-not-lazy
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L376 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L377 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L379 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L380 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L381 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L383 Use lazy % or .format() or % formatting in odoo._ functions
 
  * translation-positional-used
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L403 Translation method _('Variables not translatable: %s, %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L406 Translation method _('Variables not translatable: %s %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L409 Translation method _('Variables not translatable: %s, %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L407 Translation method _('Variables not translatable: %s, %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L410 Translation method _('Variables not translatable: %s %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L413 Translation method _('Variables not translatable: %s, %s' % (variable1, variable2)) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%(placeholder)s")` instead.
 
  * translation-required
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L353 String parameter on "message_post" requires translation. Use body=_('Body not translatable %s')
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L353 String parameter on "message_post" requires translation. Use subject=_('Subject not translatable')
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L355 String parameter on "message_post" requires translation. Use body=_('Body not translatable {}')
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L357 String parameter on "message_post" requires translation. Use body=_('Body not translatable %s')
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L357 String parameter on "message_post" requires translation. Use subject=_('Subject not translatable')
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L359 String parameter on "message_post" requires translation. Use body=_('Body not translatable {}')
 
  * translation-too-few-args
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L673 Not enough arguments for odoo._ format string
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L688 Not enough arguments for odoo._ format string
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L677 Not enough arguments for odoo._ format string
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L692 Not enough arguments for odoo._ format string
 
  * translation-too-many-args
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L678 Too many arguments for odoo._ format string
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L693 Too many arguments for odoo._ format string
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L682 Too many arguments for odoo._ format string
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L697 Too many arguments for odoo._ format string
 
  * translation-unsupported-format
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L676 Unsupported odoo._ format character 'y' (0x79) at index 30
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L691 Unsupported odoo._ format character 'y' (0x79) at index 30
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L680 Unsupported odoo._ format character 'y' (0x79) at index 30
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.5/testing/resources/test_repo/broken_module/models/broken_model.py#L695 Unsupported odoo._ format character 'y' (0x79) at index 30
 
  * use-vim-comment
 

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -914,20 +914,28 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
                         and argument.arg in ["compute", "search", "inverse"]
                         and isinstance(argument.value, nodes.Name)
                     ):
-                        self.add_message("inheritable-method-string", node=argument.value, args=(argument.value.name,))
+                        # Check if the value is a method of the class
+                        infered = utils.safe_infer(argument.value)
+                        if isinstance(infered, nodes.FunctionDef) and infered.is_method():
+                            self.add_message(
+                                "inheritable-method-string", node=argument.value, args=(argument.value.name,)
+                            )
                     if (
                         self.linter.is_message_enabled("inheritable-method-lambda", node.lineno)
                         and argument.arg in ["default", "domain"]
                         and isinstance(argument.value, nodes.Name)
                     ):
-                        self.add_message(
-                            "inheritable-method-lambda",
-                            node=argument.value,
-                            args=(
-                                argument.arg,
-                                argument.value.name,
-                            ),
-                        )
+                        # Check if the value is a method of the class
+                        infered = utils.safe_infer(argument.value)
+                        if isinstance(infered, nodes.FunctionDef) and infered.is_method():
+                            self.add_message(
+                                "inheritable-method-lambda",
+                                node=argument.value,
+                                args=(
+                                    argument.arg,
+                                    argument.value.name,
+                                ),
+                            )
 
                 if (
                     isinstance(argument_aux, nodes.Call)

--- a/testing/resources/test_repo/broken_module/models/broken_model.py
+++ b/testing/resources/test_repo/broken_module/models/broken_model.py
@@ -66,6 +66,8 @@ from itertools import groupby
 _lt = LazyTranslate(__name__)
 other_field = fields.Char()
 
+DOMAIN_GOOD = '[("type", "=", "Product")]'
+
 
 def function_no_method():
     return broken_model1, broken_module1, broken_module2, broken_model2
@@ -106,6 +108,8 @@ class TestModel2(odoo.models.Model):
     domain2 = fields.Many2one("res.partner", domain=lambda self: self._domain())  # good domain
     domain3 = fields.Many2one("res.partner", domain=[("type", "=", "Product")])  # good domain
     domain4 = fields.Many2one("res.partner", domain='[("type", "=", "Product")]')  # good domain
+    domain5 = fields.Many2one("res.partner", domain='[("type", "=", "Product")]')  # good domain
+    domain6 = fields.Many2one("res.partner", domain=DOMAIN_GOOD)  # good domain
 
     def fields_view_get(self):
         return "Deprecated in Odoo 16.0!!!"


### PR DESCRIPTION
Fix the following case of code

```python
    DOMAIN = "[]"

        field1 = fields.Many2one("res.partner", domain=DOMAIN)
```

It is a valid case

So, only considering methods from classes used

```python
    def _domain(self):
        pass

    field1 = fields.Many2one("res.partner", domain=_domain)
```