### PR TITLE
[FIX] no-search-all: Fix `domain` variable used before to be assigned

### DIFF
--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -1097,12 +1097,8 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
         ):
             if node.args:
                 domain = node.args[0]
-            elif node.keywords:
-                for keyword in node.keywords:
-                    if keyword.arg != "domain":
-                        continue
-                    domain = keyword.value
-                    break
+            else:
+                domain = next((kw.value for kw in node.keywords if kw.arg == "domain"), None)
             if domain:
                 empty_domain = False
                 if isinstance(domain, nodes.List) and not domain.elts:

--- a/testing/resources/test_repo/broken_module/models/broken_model.py
+++ b/testing/resources/test_repo/broken_module/models/broken_model.py
@@ -153,6 +153,9 @@ class TestModel2(odoo.models.Model):
         self.search_read(domain40)  # good domain
         self.search_read(domain=domain40)  # good domain
 
+        self.search(limit=1)  # first arg required
+        self.search_read(limit=1)  # first arg required
+
 
     def _default(self):
         pass


### PR DESCRIPTION
If the method search does not have `domain` parameter pylint-odoo crashes

This fix consider this weird case