### PR TITLE
[FIX] translation-format-interpolation: Fix false negative for translate using "".format() style

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,9 +389,9 @@ Checks valid only for odoo <= 13.0
 
  * translation-format-interpolation
 
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.13/testing/resources/test_repo/broken_module/models/broken_model.py#L457 Use lazy % or .format() or % formatting in odoo._ functions
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.13/testing/resources/test_repo/broken_module/models/broken_model.py#L465 Use lazy % or .format() or % formatting in odoo._ functions
     - https://github.com/OCA/pylint-odoo/blob/v9.3.13/testing/resources/test_repo/broken_module/models/broken_model.py#L490 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.13/testing/resources/test_repo/broken_module/models/broken_model.py#L491 Use lazy % or .format() or % formatting in odoo._ functions
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.13/testing/resources/test_repo/broken_module/models/broken_model.py#L554 Use lazy % or .format() or % formatting in odoo._ functions
 
  * translation-format-truncated
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -64,7 +64,7 @@ EXPECTED_ERRORS = {
     "test-folder-imported": 3,
     "translation-contains-variable": 33,
     "translation-field": 3,
-    "translation-format-interpolation": 8,
+    "translation-format-interpolation": 22,
     "translation-format-truncated": 2,
     "translation-fstring-interpolation": 3,
     "translation-not-lazy": 42,


### PR DESCRIPTION
Using the following way is not detected:
  - `self.env._("{param1}").format(param1="hello")`

Since that the original logger is returning `None` value and it is processing the following expected way:
  - `self.env._("{param1}".format(param1="hello"))`

It is similar to use Binary Operator:
  - `self.env._("%s") % "hello"`

instead of:
  - `self.env._("%s" % "hello")`

However, It was already considered from `transform_binop2call` method from:
 - https://github.com/OCA/pylint-odoo/pull/423

But we have missed the `"".format()` way

This commit adds the `transform_formatcall2tlcall` method similar to `transform_binop2call`


Reported by @luisg123v from customer CI build