### PR TITLE
[REF] category-allowed: Restrict categories to match Odoo Apps filters (only for apps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Short Name | Description | Code
 attribute-deprecated | attribute "%s" deprecated | W8105
 attribute-string-redundant | The attribute string is redundant. String parameter equal to name of variable | W8113
 bad-builtin-groupby | Used builtin function `itertools.groupby`. Prefer `odoo.tools.groupby` instead. More info about https://github.com/odoo/odoo/issues/105376 | W8155
-category-allowed | Category "%s" not allowed in manifest file. | C8114
+category-allowed | Category "%s" not allowed in %smanifest file. | C8114
 consider-merging-classes-inherited | Consider merging classes inherited to "%s" from %s. | R8180
 context-overridden | Context overridden using dict. Better using kwargs `with_context(**%s)` or `with_context(key=value)` | W8121
 deprecated-name-get | 'name_get' is deprecated. Use '_compute_display_name' instead. More info at https://github.com/odoo/odoo/pull/122085. | E8146
@@ -171,6 +171,10 @@ Checks valid only for odoo <= 13.0
     - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/models/broken_model.py#L205 Used builtin function `itertools.groupby`. Prefer `odoo.tools.groupby` instead. More info about https://github.com/odoo/odoo/issues/105376
     - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/models/broken_model.py#L206 Used builtin function `itertools.groupby`. Prefer `odoo.tools.groupby` instead. More info about https://github.com/odoo/odoo/issues/105376
 
+ * category-allowed
+
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L6 Category "No valid for odoo.com/apps" not allowed in app manifest file.
+
  * consider-merging-classes-inherited
 
     - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/models/model_inhe2.py#L11 Consider merging classes inherited to "res.company" from testing/resources/test_repo/broken_module/models/model_inhe1.py:8:4, testing/resources/test_repo/broken_module/models/model_inhe2.py:7:4.
@@ -244,11 +248,11 @@ Checks valid only for odoo <= 13.0
 
  * manifest-data-duplicated
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L18 The file "duplicated.xml" is duplicated in lines 19 from manifest key "data"
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L19 The file "duplicated.xml" is duplicated in lines 20 from manifest key "data"
 
  * manifest-deprecated-key
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L7 Deprecated key "description" in manifest file
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L8 Deprecated key "description" in manifest file
 
  * manifest-external-assets
 
@@ -272,7 +276,7 @@ Checks valid only for odoo <= 13.0
 
  * manifest-version-format
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L8 Wrong Version Format "8_0.1.0.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L9 Wrong Version Format "8_0.1.0.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
     - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module2/__openerp__.py#L8 Wrong Version Format "1.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
     - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module3/__openerp__.py#L8 Wrong Version Format "8.0.1.0.0foo" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
 
@@ -359,9 +363,9 @@ Checks valid only for odoo <= 13.0
 
  * resource-not-exist
 
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L14 File "data": "file_no_exist.xml" not found.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L18 File "data": "duplicated.xml" not found.
-    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L23 File "demo": "file_no_exist.xml" not found.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L15 File "data": "file_no_exist.xml" not found.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L19 File "data": "duplicated.xml" not found.
+    - https://github.com/OCA/pylint-odoo/blob/v9.3.16/testing/resources/test_repo/broken_module/__openerp__.py#L24 File "demo": "file_no_exist.xml" not found.
 
  * sql-injection
 

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -154,7 +154,7 @@ ODOO_MSGS = {
         "no-wizard-in-models",
         CHECK_DESCRIPTION,
     ),
-    "C8114": ('Category "%s" not allowed in manifest file.', "category-allowed", CHECK_DESCRIPTION),
+    "C8114": ('Category "%s" not allowed in %smanifest file.', "category-allowed", CHECK_DESCRIPTION),
     "C8115": (
         "Missing %s %sfile",
         "missing-odoo-file",
@@ -341,6 +341,27 @@ DFTL_ATTRIBUTE_DEPRECATED = [
     "length",
 ]
 DFTL_CATEGORY_ALLOWED = []
+DFTL_CATEGORY_ALLOWED_APP = [
+    # Based on https://apps.odoo.com/apps
+    "Accounting",
+    "Discuss",
+    "Document Management",
+    "eCommerce",
+    "Extra Tools",
+    "Human Resources",
+    "Industries",
+    "Localization",
+    "Manufacturing",
+    "Marketing",
+    "Point of Sale",
+    "Productivity",
+    "Project",
+    "Purchases",
+    "Sales",
+    "Tutorial",
+    "Warehouse",
+    "Website",
+]
 DFTL_METHOD_REQUIRED_SUPER = [
     "copy",
     "create",
@@ -628,6 +649,15 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
                 "metavar": "<comma separated values>",
                 "default": DFTL_CATEGORY_ALLOWED,
                 "help": "List of categories allowed in manifest file, separated by a comma.",
+            },
+        ),
+        (
+            "category-allowed-app",
+            {
+                "type": "csv",
+                "metavar": "<comma separated values>",
+                "default": DFTL_CATEGORY_ALLOWED_APP,
+                "help": "List of categories allowed in manifest file for apps, separated by a comma.",
             },
         ),
     )
@@ -1303,9 +1333,10 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             category_str
             and self.linter.config.category_allowed
             and category_str not in self.linter.config.category_allowed
+            and "price" not in manifest_dict
         ):
             self.add_message(
-                "category-allowed", node=manifest_keys_nodes.get("category") or node, args=(category_str,)
+                "category-allowed", node=manifest_keys_nodes.get("category") or node, args=(category_str, "")
             )
 
         # Check version format
@@ -1441,6 +1472,21 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
                             "app ",
                         ),
                     )
+
+            # Check category allowed for apps
+            if (
+                category_str
+                and self.linter.config.category_allowed_app
+                and category_str not in self.linter.config.category_allowed_app
+            ):
+                self.add_message(
+                    "category-allowed",
+                    node=manifest_keys_nodes.get("category") or node,
+                    args=(
+                        category_str,
+                        "app ",
+                    ),
+                )
 
     def _check_manifest_external_assets(self, node):
         def is_external_url(url):

--- a/testing/resources/test_repo/broken_module/__openerp__.py
+++ b/testing/resources/test_repo/broken_module/__openerp__.py
@@ -3,6 +3,7 @@
     'name': 'Broken module for tests',
     # missing license
     'author': 'Vauxoo, Many People',  # Missing oca author
+    'category': 'No valid for odoo.com/apps',  # raised category-allowed
     'development_status': 'Alpha',
     'description': 'Should be a README.rst file',
     'version': '8_0.1.0.0',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,6 +22,7 @@ EXPECTED_ERRORS = {
     "attribute-deprecated": 3,
     "attribute-string-redundant": 31,
     "bad-builtin-groupby": 2,
+    "category-allowed": 1,
     "consider-merging-classes-inherited": 2,
     "context-overridden": 3,
     "deprecated-name-get": 1,
@@ -417,17 +418,20 @@ def fstring_no_sqli(self):
     # Test category-allowed with and without error
     def test_170_category_allowed(self):
         extra_params = ["--disable=all", "--enable=category-allowed", "--category-allowed=Category 00"]
-        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        pylint_res = self.run_pylint(self.paths_modules, extra_params, verbose=True)
         real_errors = pylint_res.linter.stats.by_msg
         expected_errors = {
-            "category-allowed": 1,
+            "category-allowed": 2,
         }
         self.assertDictEqual(real_errors, expected_errors)
 
+        expected_errors = {
+            "category-allowed": 1,
+        }
         extra_params = ["--disable=all", "--enable=category-allowed", "--category-allowed=Category 01"]
-        pylint_res = self.run_pylint(self.paths_modules, extra_params)
+        pylint_res = self.run_pylint(self.paths_modules, extra_params, verbose=True)
         real_errors = pylint_res.linter.stats.by_msg
-        self.assertFalse(real_errors)
+        self.assertDictEqual(real_errors, expected_errors)
 
     def test_option_odoo_deprecated_model_method(self):
         pylint_res = self.run_pylint(


### PR DESCRIPTION
Odoo Apps (https://apps.odoo.com/apps) only supports a limited set of categories,
matched exactly using the `=` operator.
    - <img width="262" height="775" alt="apps" src="https://github.com/user-attachments/assets/5ddb65c4-5410-4ba8-b079-f5a258d5bb32" />
    - Categories not listed there will not be shown.
    - Nested categories (e.g. category/subcategory) are also ignored.

To ensure apps are correctly filtered and displayed under the intended category,

It introduces a new section that restricts the allowed categories only for apps
(modules with `price` key in the manifest)

Continuation of https://github.com/OCA/pylint-odoo/pull/459
