### PR TITLE
[REF] super-method-mismatch: Consider queue and cache defined methods as valid

### DIFF
--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -1265,7 +1265,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
         ):
             meth_called = self.get_func_name(node.func)
             meth_defined = frame.name
-            if meth_called != meth_defined:
+            if meth_called != meth_defined and "queue" not in meth_defined and "cache" not in meth_defined:
                 self.add_message("super-method-mismatch", node=node, args=(meth_called, meth_defined))
 
     @utils.only_required_for_messages(

--- a/testing/resources/test_repo/broken_module/tests/test_model.py
+++ b/testing/resources/test_repo/broken_module/tests/test_model.py
@@ -35,3 +35,13 @@ class TestModel(TransactionCase):
         some_obj.test_base_method_3()
         # Override prohibited, should fail
         return super(TestModel, self).test_base_method_3()
+
+    def message_post_queued(self, *args, **kwargs):
+        # super-method-mismatch valid since that it is enqueued the method
+        # not calling the same super method
+        return super().message_post(*args, **kwargs)
+
+    def get_meth_cached(self):
+        # super-method-mismatch valid since that it is caching the method
+        # not calling the same super method
+        return super().get_meth().ids


### PR DESCRIPTION


It is common generating a super calling the original method but defining a cache or queue method in order to support the feature correctly

So, it is a valid super-method-mismatch case

Now supported