### PR TITLE
[ADD] manifest-summary-multiline: Detect newline in summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ manifest-maintainers-list | The maintainers key in the manifest file must be a l
 manifest-required-author | One of the following authors must be present in manifest: %s | C8101
 manifest-required-key | Missing required key "%s" in manifest file | C8102
 manifest-required-key-app | Missing required key "%s" in manifest file for modules with price. | C8119
+manifest-summary-multiline | Summary in manifest file should be a one-line short description, found newline character | C8120
 manifest-superfluous-key | Manifest superfluous key "%s". It is the same as the default value: %s. Better remove it | C8116
 manifest-version-format | Wrong Version Format "%s" in manifest file. Regex to match: "%s" | C8106
 method-compute | Name of compute method should start with "_compute_" | C8108
@@ -242,7 +243,7 @@ Checks valid only for odoo <= 13.0
 
  * invalid-email
 
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module2/__openerp__.py#L13 Invalid email "invalidmail.com"
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module2/__openerp__.py#L15 Invalid email "invalidmail.com"
 
  * license-allowed
 
@@ -260,11 +261,11 @@ Checks valid only for odoo <= 13.0
 
  * manifest-data-duplicated
 
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L19 The file "duplicated.xml" is duplicated in lines 20 from manifest key "data"
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L20 The file "duplicated.xml" is duplicated in lines 21 from manifest key "data"
 
  * manifest-deprecated-key
 
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L8 Deprecated key "description" in manifest file
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L9 Deprecated key "description" in manifest file
 
  * manifest-external-assets
 
@@ -290,16 +291,21 @@ Checks valid only for odoo <= 13.0
     - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/app_module/__manifest__.py#L1 Missing required key "images" in manifest file for modules with price.
     - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L2 Missing required key "currency" in manifest file for modules with price.
 
+ * manifest-summary-multiline
+
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L8 Summary in manifest file should be a one-line short description, found newline character
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module2/__openerp__.py#L8 Summary in manifest file should be a one-line short description, found newline character
+
  * manifest-superfluous-key
 
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L26 Manifest superfluous key "installable". It is the same as the default value: True. Better remove it
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L28 Manifest superfluous key "active". It is the same as the default value: True. Better remove it
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L29 Manifest superfluous key "auto_install". It is the same as the default value: False. Better remove it
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L27 Manifest superfluous key "installable". It is the same as the default value: True. Better remove it
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L29 Manifest superfluous key "active". It is the same as the default value: True. Better remove it
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L30 Manifest superfluous key "auto_install". It is the same as the default value: False. Better remove it
 
  * manifest-version-format
 
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L9 Wrong Version Format "8_0.1.0.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module2/__openerp__.py#L8 Wrong Version Format "1.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L10 Wrong Version Format "8_0.1.0.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module2/__openerp__.py#L10 Wrong Version Format "1.0" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
     - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module3/__openerp__.py#L8 Wrong Version Format "8.0.1.0.0foo" in manifest file. Regex to match: "(4\.2|5\.0|6\.0|6\.1|7\.0|8\.0|9\.0|10\.0|11\.0|12\.0|13\.0|14\.0|15\.0|16\.0|17\.0|18\.0|19\.0)\.\d+\.\d+\.\d+$"
 
  * method-compute
@@ -385,9 +391,9 @@ Checks valid only for odoo <= 13.0
 
  * resource-not-exist
 
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L15 File "data": "file_no_exist.xml" not found.
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L19 File "data": "duplicated.xml" not found.
-    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L24 File "demo": "file_no_exist.xml" not found.
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L16 File "data": "file_no_exist.xml" not found.
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L20 File "data": "duplicated.xml" not found.
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/__openerp__.py#L25 File "demo": "file_no_exist.xml" not found.
 
  * sql-injection
 

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -180,6 +180,11 @@ ODOO_MSGS = {
         "manifest-required-key-app",
         CHECK_DESCRIPTION,
     ),
+    "C8120": (
+        "Summary in manifest file should be a one-line short description, found newline character",
+        "manifest-summary-multiline",
+        CHECK_DESCRIPTION,
+    ),
     "E8101": (
         "The author key in the manifest file must be a string (with comma separated values)",
         "manifest-author-string",
@@ -1348,6 +1353,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
         "manifest-required-author",
         "manifest-required-key-app",
         "manifest-required-key",
+        "manifest-summary-multiline",
         "manifest-superfluous-key",
         "manifest-version-format",
         "missing-odoo-file-app",
@@ -1518,6 +1524,11 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             not isinstance(maintainers, list) or any(not isinstance(item, str) for item in maintainers)
         ):
             self.add_message("manifest-maintainers-list", node=manifest_keys_nodes.get("maintainers") or node)
+
+        # Check summary is a single line
+        summary = manifest_dict.get("summary")
+        if isinstance(summary, str) and "\n" in summary:
+            self.add_message("manifest-summary-multiline", node=manifest_keys_nodes.get("summary") or node)
 
         # Check there are no external assets
         if self.linter.is_message_enabled("manifest-external-assets"):

--- a/testing/resources/test_repo/broken_module/__openerp__.py
+++ b/testing/resources/test_repo/broken_module/__openerp__.py
@@ -5,6 +5,7 @@
     'author': 'Vauxoo, Many People',  # Missing oca author
     'category': 'No valid for odoo.com/apps',  # raised category-allowed
     'development_status': 'Alpha',
+    'summary': 'Short description\nwith a second line',
     'description': 'Should be a README.rst file',
     'version': '8_0.1.0.0',
     'website': 'https://odoo-community.org',

--- a/testing/resources/test_repo/broken_module2/__openerp__.py
+++ b/testing/resources/test_repo/broken_module2/__openerp__.py
@@ -5,6 +5,8 @@
     'author': 'Other,Odoo Community Association (OCA)',  # Missing oca author
     'development_status': 'InvalidDevStatus',
     'website': 'https://odoo-community.org,https://odoo.com',
+    'summary': """
+    Instance creator for odoo modules""",
     'version': '1.0',
     'depends': ['base'],
     'data': [],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,6 +45,7 @@ EXPECTED_ERRORS = {
     "manifest-required-author": 1,
     "manifest-required-key-app": 5,
     "manifest-required-key": 1,
+    "manifest-summary-multiline": 2,
     "manifest-superfluous-key": 7,
     "manifest-version-format": 3,
     "method-compute": 2,


### PR DESCRIPTION
## Summary
- Adds new check `manifest-summary-multiline` (C8120, Convention) that detects newline characters (`\n`) in the `summary` field of Odoo module manifests.
- Odoo expects `summary` to be a single-line string. When it contains `\n`, Odoo raises `AssertionError` at runtime. This check catches it at lint time.
- Includes test fixtures in `broken_module` and `broken_module2` with two different violation patterns.

