### PR TITLE
[ADD] translation-injection: Detect str.format() inside Odoo translation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ translation-field | Translation method _("string") in fields is not necessary. |
 translation-format-interpolation | Use %s formatting in odoo._ functions | W8302
 translation-format-truncated | Logging format string ends in middle of conversion specifier | E8301
 translation-fstring-interpolation | Use %s formatting in odoo._ functions | W8303
+translation-injection | Do not use str.format on translation methods. Use placeholders instead. Reference: https://lucumr.pocoo.org/2016/12/29/careful-with-str-format/ | E8151
 translation-not-lazy | Use %s formatting in odoo._ functions | W8301
 translation-positional-used | Translation method _(%s) is using positional string printf formatting with multiple arguments. Use named placeholder `_("%%(placeholder)s")` instead. | W8120
 translation-required | String parameter on "%s" requires translation. Use %s%s(%s) | C8107
@@ -435,6 +436,12 @@ Checks valid only for odoo <= 13.0
     - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/models/broken_model.py#L268 Use lazy % or .format() or % formatting in odoo._ functions
     - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/models/broken_model.py#L772 Use lazy % or .format() or % formatting in odoo._ functions
     - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/models/broken_model.py#L787 Use lazy % or .format() or % formatting in odoo._ functions
+
+ * translation-injection
+
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/models/broken_model.py#L506 Do not use str.format on translation methods. Use placeholders instead. Reference: https://lucumr.pocoo.org/2016/12/29/careful-with-str-format/
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/models/broken_model.py#L507 Do not use str.format on translation methods. Use placeholders instead. Reference: https://lucumr.pocoo.org/2016/12/29/careful-with-str-format/
+    - https://github.com/OCA/pylint-odoo/blob/v10.0.2/testing/resources/test_repo/broken_module/models/broken_model.py#L570 Do not use str.format on translation methods. Use placeholders instead. Reference: https://lucumr.pocoo.org/2016/12/29/careful-with-str-format/
 
  * translation-not-lazy
 

--- a/src/pylint_odoo/checkers/odoo_addons.py
+++ b/src/pylint_odoo/checkers/odoo_addons.py
@@ -242,6 +242,12 @@ ODOO_MSGS = {
         "deprecated-inselect-operator",
         CHECK_DESCRIPTION,
     ),
+    "E8151": (
+        "Do not use str.format on translation methods. Use placeholders instead. "
+        "Reference: https://lucumr.pocoo.org/2016/12/29/careful-with-str-format/",
+        "translation-injection",
+        CHECK_DESCRIPTION,
+    ),
     "F8101": ('File "%s": "%s" not found.', "resource-not-exist", CHECK_DESCRIPTION),
     "R8101": (
         "`odoo.exceptions.Warning` is a deprecated alias to `odoo.exceptions.UserError` "
@@ -1034,6 +1040,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
         "super-method-mismatch",
         "translation-contains-variable",
         "translation-field",
+        "translation-injection",
         "translation-positional-used",
         "translation-required",
     )
@@ -1214,6 +1221,15 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
             wrong = ""
             right = ""
             arg = node.args[0]
+            arg_func_infer_qname = None
+
+            # translation methods with .format usage
+            if isinstance(arg, nodes.Call) and (func_safe_infer := utils.safe_infer(arg.func)):
+                arg_func_infer_qname = func_safe_infer.qname()
+
+            if arg_func_infer_qname == "builtins.str.format":
+                self.add_message("translation-injection", node=node)
+
             # case: _('...' % (variables))
             if isinstance(arg, nodes.BinOp) and arg.op == "%":
                 wrong = "%s %% %s" % (arg.left.as_string(), arg.right.as_string())
@@ -1223,7 +1239,7 @@ class OdooAddons(OdooBaseChecker, BaseChecker):
                 isinstance(arg, nodes.Call)
                 and isinstance(arg.func, nodes.Attribute)
                 and isinstance(arg.func.expr, nodes.Const)
-                and arg.func.attrname == "format"
+                and arg_func_infer_qname == "builtins.str.format"
             ):
                 wrong = arg.as_string()
                 params_as_string = ", ".join([x.as_string() for x in itertools.chain(arg.args, arg.keywords or [])])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,6 +72,7 @@ EXPECTED_ERRORS = {
     "translation-format-interpolation": 22,
     "translation-format-truncated": 2,
     "translation-fstring-interpolation": 3,
+    "translation-injection": 12,
     "translation-not-lazy": 42,
     "translation-positional-used": 30,
     "translation-required": 16,


### PR DESCRIPTION
Add new check 'translation-injection' that detects when `str.format()` is used inside Odoo translation methods such as `_()` or `_lt()` or `self.env._``

This pattern is dangerous because it allows untrusted user-provided data to be injected into the translation string format, potentially bypassing proper translation and leading to security or behavioral issues.

More info about:
- https://lucumr.pocoo.org/2016/12/29/careful-with-str-format/

Related to https://github.com/OCA/odoo-pre-commit-hooks/pull/192
